### PR TITLE
[SC-5] Governance Contract Initialization

### DIFF
--- a/smartcontract/contracts/governance/src/lib.rs
+++ b/smartcontract/contracts/governance/src/lib.rs
@@ -172,6 +172,10 @@ impl GovernanceContract {
             return Err(Error::AlreadyInitialized);
         }
 
+        if quorum_percent < 1 || quorum_percent > 100 {
+            return Err(Error::InvalidProposal);
+        }
+
         admin.require_auth();
 
         env.storage().instance().set(&DataKey::Initialized, &true);


### PR DESCRIPTION
## Summary
- Implements quorum_percent validation (1-100) in the governance contract `initialize` function
- The initialize function already stores governance parameters in Instance storage and emits `(gov, init)` event

## Changes
- Added validation check to ensure quorum_percent is between 1 and 100

Closes #23