### PR TITLE
[SC-9] Multi-Sig Approval Logic

### DIFF
--- a/smartcontract/contracts/treasury/src/lib.rs
+++ b/smartcontract/contracts/treasury/src/lib.rs
@@ -319,6 +319,9 @@ impl TreasuryContract {
     /// * `signer` - The signer approving the transaction.
     /// * `tx_id` - The ID of the transaction to approve.
     ///
+    /// # Returns
+    /// The current approval count.
+    ///
     /// # Errors
     /// * `Error::NotASigner` - If the caller is not a signer.
     /// * `Error::TransactionNotFound` - If the transaction doesn't exist.
@@ -865,8 +868,7 @@ mod test {
             symbol_short!("propose").into_val(&env),
         ];
         assert_eq!(event.1, expected_topics);
-        let expected_data: Val =
-            (tx_id, signer1, recipient, 1_000_000_i128).into_val(&env);
+        let expected_data: Val = (tx_id, signer1, recipient, 1_000_000_i128).into_val(&env);
         assert_eq!(event.2, expected_data);
     }
 
@@ -924,8 +926,7 @@ mod test {
             symbol_short!("execute").into_val(&env),
         ];
         assert_eq!(event.1, expected_topics);
-        let expected_data: Val =
-            (tx_id, recipient, 1_000_000_i128, 4_000_000_i128).into_val(&env);
+        let expected_data: Val = (tx_id, recipient, 1_000_000_i128, 4_000_000_i128).into_val(&env);
         assert_eq!(event.2, expected_data);
     }
 }


### PR DESCRIPTION
## Summary
Confirms that the `approve` function for multi-sig transaction approval is already fully implemented in the treasury contract at `smartcontract/contracts/treasury/src/lib.rs:327-374`.

## Implementation Details
The existing `approve` function meets all requirements from issue #42:
- Implements `approve(env, signer, tx_id)`
- Verifies signer is authorized (`require_signer`)
- Checks transaction exists and is not already executed
- Prevents duplicate approvals from same signer
- Adds signer to approvals list
- Returns current approval count
- Emits `(treasury, approve)` event

Closes #42