### PR TITLE
[SC-10] Withdrawal Execution

### DIFF
--- a/smartcontract/contracts/treasury/src/lib.rs
+++ b/smartcontract/contracts/treasury/src/lib.rs
@@ -384,11 +384,15 @@ impl TreasuryContract {
     /// * `executor` - The signer executing the transaction.
     /// * `tx_id` - The ID of the transaction to execute.
     ///
+    /// # Returns
+    /// Ok(()) on successful execution.
+    ///
     /// # Errors
     /// * `Error::NotASigner` - If executor is not a signer.
     /// * `Error::TransactionNotFound` - If the transaction doesn't exist.
     /// * `Error::AlreadyExecuted` - If already executed.
     /// * `Error::Unauthorized` - If approval threshold not met.
+    /// * `Error::InsufficientFunds` - If treasury has insufficient balance.
     pub fn execute(env: Env, executor: Address, tx_id: u64) -> Result<(), Error> {
         Self::require_initialized(&env)?;
         Self::require_signer(&env, &executor)?;


### PR DESCRIPTION
## Summary
Confirms that the `execute` function for withdrawal execution is already fully implemented in the treasury contract at `smartcontract/contracts/treasury/src/lib.rs:392-449`.

## Implementation Details
The existing `execute` function meets all requirements from issue #43:
- Implements `execute(env, executor, tx_id)`
- Checks approval count meets threshold
- Deducts balance from treasury
- Marks transaction as executed
- Emits `(treasury, execute)` event with recipient and amount

Closes #43