### PR TITLE
feat: wire treasury dashboard and interaction UX

### DIFF
--- a/frontend/src/app/treasury/page.tsx
+++ b/frontend/src/app/treasury/page.tsx
@@ -1,182 +1,339 @@
 "use client";
 
-import { useTreasury, TreasuryTransaction } from "@/hooks/useTreasury";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useTreasury } from "@/hooks/useTreasury";
 import { useFreighter } from "@/hooks/useFreighter";
+import { formatAbsoluteDate, formatAddress, formatXlm } from "@/lib/formatters";
+import { ERROR_CODE_LABELS } from "@/lib/errors";
+import { TreasuryCard } from "@/components/TreasuryCard";
+import { WalletConnect } from "@/components/WalletConnect";
+import { ConfirmationDialog } from "@/components/ConfirmationDialog";
+import { CopyButton } from "@/components/CopyButton";
+import type { TreasuryTransaction } from "@/lib/contractData";
 
 export default function TreasuryPage() {
   const { address } = useFreighter();
-  const { balance, config, transactions, isLoading } = useTreasury();
-  const [selectedTx, setSelectedTx] = useState<TreasuryTransaction | null>(null);
+  const {
+    balance,
+    config,
+    transactions,
+    isLoading,
+    error,
+    isNetworkMismatch,
+    pendingActions,
+    approve,
+    execute,
+    refresh,
+    clearError,
+  } = useTreasury();
 
-  // Simple heuristic for demo purposes: consider transactions 'Pending' if topic_1 implies propose or they lack an execution event
-  const pendingTxs = transactions.filter(t => t.topic_1 && t.topic_1.includes('propose'));
-  const historyTxs = transactions.filter(t => !t.topic_1?.includes('propose'));
+  const [selectedTx, setSelectedTx] = useState<TreasuryTransaction | null>(null);
+  const [confirmExecuteTxId, setConfirmExecuteTxId] = useState<number | null>(null);
+
+  const pendingTxs = useMemo(
+    () => transactions.filter((transaction) => !transaction.executed),
+    [transactions],
+  );
+
+  const historyTxs = useMemo(
+    () => transactions.filter((transaction) => transaction.executed),
+    [transactions],
+  );
+
+  const threshold = config?.threshold ?? 0;
+  const signerCount = config?.signerCount ?? 0;
+
+  const handleApprove = async (txId: number) => {
+    await approve(txId);
+  };
+
+  const handleExecute = (txId: number) => {
+    setConfirmExecuteTxId(txId);
+  };
+
+  const runExecute = async () => {
+    if (confirmExecuteTxId === null) {
+      return;
+    }
+
+    await execute(confirmExecuteTxId);
+    setConfirmExecuteTxId(null);
+  };
 
   return (
     <div className="space-y-8 relative">
-      <div className="flex justify-between items-center">
+      <div className="flex flex-col gap-4 md:flex-row md:justify-between md:items-center">
         <div>
           <h1 className="text-3xl font-bold text-white">Treasury</h1>
           <p className="text-gray-400 mt-1">
-            Manage shared funds with multi-signature approvals
+            Live treasury status and approvals from Soroban contracts.
           </p>
         </div>
-        <button className="btn-primary">+ Deposit</button>
+        <div className="flex gap-2 items-center">
+          <button className="btn-secondary text-sm" onClick={() => refresh()}>
+            {isLoading ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
       </div>
 
-      {/* Balance Overview */}
+      {isNetworkMismatch && (
+        <div className="card border-red-500/40 bg-red-950/20">
+          <h2 className="text-sm font-semibold text-red-300">Network mismatch</h2>
+          <p className="text-sm text-red-200 mt-1">
+            Your wallet is on a different network than the configured contracts.
+            Switch networks in Freighter, then retry.
+          </p>
+        </div>
+      )}
+
+      {!address && (
+        <div className="card border-yellow-500/40 bg-yellow-950/20">
+          <h2 className="text-sm font-semibold text-yellow-300">Wallet disconnected</h2>
+          <p className="text-sm text-yellow-200 mt-1">
+            Connect your wallet to approve or execute treasury transactions.
+          </p>
+          <div className="mt-4 inline-flex">
+            <WalletConnect />
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="card border-red-500/40 bg-red-950/20">
+          <h2 className="text-sm font-semibold text-red-300">
+            {ERROR_CODE_LABELS[error.code]}
+          </h2>
+          <p className="text-sm text-red-200 mt-1">{error.message}</p>
+          <div className="mt-4 flex gap-2">
+            {error.recoverable && (
+              <button className="btn-primary text-sm" onClick={() => refresh()}>
+                Retry
+              </button>
+            )}
+            <button className="btn-secondary text-sm" onClick={clearError}>
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="card">
-        <div className="flex justify-between items-center">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
           <div>
-            <p className="text-sm text-gray-400">Total Balance</p>
-            <p className="text-4xl font-bold text-white mt-1">
-              {isLoading && balance === 0 ? "..." : balance} XLM
+            <p className="text-sm text-gray-400">Treasury Balance</p>
+            <p className="text-3xl font-bold text-white mt-1">
+              {isLoading && balance === 0n ? "Loading..." : `${formatXlm(balance)} XLM`}
             </p>
           </div>
-          <div className="text-right">
+          <div>
             <p className="text-sm text-gray-400">Approval Threshold</p>
             <p className="text-2xl font-semibold text-primary-400 mt-1">
-              {config?.threshold || "—"} of {config?.signer_count || "—"}
+              {threshold > 0 ? `${threshold} of ${signerCount}` : "-"}
             </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-400">Admin</p>
+            <div className="flex items-center gap-2 mt-1">
+              <p className="text-sm text-gray-200 font-mono">
+                {config?.admin ? formatAddress(config.admin, { startChars: 6, endChars: 4 }) : "-"}
+              </p>
+              {config?.admin && (
+                <CopyButton value={config.admin} label="treasury admin address" />
+              )}
+            </div>
           </div>
         </div>
       </div>
 
-      {/* Pending Transactions */}
       <div>
-        <h2 className="text-xl font-semibold text-white mb-4">
-          Pending Transactions
-        </h2>
-        <div className="card">
-          {!address ? (
-            <p className="text-gray-500 text-center py-8">
-              Connect your wallet to view pending transactions
-            </p>
-          ) : pendingTxs.length === 0 ? (
-            <p className="text-gray-500 text-center py-8">
-              No pending transactions
-            </p>
-          ) : (
-            <div className="space-y-4">
-              {pendingTxs.map(tx => (
-                <div key={tx.id} className="flex justify-between items-center p-4 bg-gray-900 rounded-lg border border-stellar-border cursor-pointer hover:bg-gray-800 transition" onClick={() => setSelectedTx(tx)}>
-                  <div>
-                    <p className="text-sm font-semibold text-white">Transaction #{tx.id}</p>
-                    <p className="text-xs text-gray-400 mt-1">{tx.topic_1 || "Unknown"}</p>
-                  </div>
-                  <div className="text-right">
-                    <span className="px-2 py-1 bg-yellow-900/50 text-yellow-400 border border-yellow-700 rounded text-xs">Pending</span>
-                  </div>
-                </div>
-              ))}
+        <h2 className="text-xl font-semibold text-white mb-4">Pending Transactions</h2>
+        <div className="space-y-4">
+          {pendingTxs.length === 0 ? (
+            <div className="card">
+              <p className="text-gray-500 text-center py-8">
+                {isLoading ? "Loading transactions..." : "No pending transactions."}
+              </p>
             </div>
+          ) : (
+            pendingTxs.map((transaction) => (
+              <div
+                key={transaction.id}
+                className="cursor-pointer"
+                onClick={() => setSelectedTx(transaction)}
+              >
+                <TreasuryCard
+                  txId={transaction.id}
+                  to={transaction.to}
+                  amount={transaction.amount}
+                  memo={transaction.memo}
+                  approvals={transaction.approvals}
+                  threshold={threshold || 1}
+                  executed={transaction.executed}
+                  isPendingApproval={pendingActions.get(transaction.id) === "approve"}
+                  isPendingExecution={pendingActions.get(transaction.id) === "execute"}
+                  onApprove={isNetworkMismatch || !address ? undefined : handleApprove}
+                  onExecute={isNetworkMismatch || !address ? undefined : handleExecute}
+                />
+              </div>
+            ))
           )}
         </div>
       </div>
 
-      {/* Transaction History */}
       <div>
-        <h2 className="text-xl font-semibold text-white mb-4">History</h2>
-        <div className="card">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-gray-400 border-b border-stellar-border">
-                  <th className="text-left py-3 px-4">ID</th>
-                  <th className="text-left py-3 px-4">Event Topic</th>
-                  <th className="text-left py-3 px-4">Ledger</th>
-                  <th className="text-left py-3 px-4">Date</th>
+        <h2 className="text-xl font-semibold text-white mb-4">Execution History</h2>
+        <div className="card overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-gray-400 border-b border-stellar-border">
+                <th className="text-left py-3 px-4">ID</th>
+                <th className="text-left py-3 px-4">Destination</th>
+                <th className="text-left py-3 px-4">Amount</th>
+                <th className="text-left py-3 px-4">Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {historyTxs.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="text-center text-gray-500 py-8">
+                    {isLoading ? "Loading execution history..." : "No executed transactions."}
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {isLoading && historyTxs.length === 0 ? (
-                  <tr>
-                    <td colSpan={4} className="text-center text-gray-400 py-8">Loading history...</td>
+              ) : (
+                historyTxs.map((transaction) => (
+                  <tr
+                    key={transaction.id}
+                    className="border-b border-stellar-border/50 hover:bg-gray-800/50 cursor-pointer transition"
+                    onClick={() => setSelectedTx(transaction)}
+                  >
+                    <td className="py-3 px-4 text-white">
+                      <div className="flex items-center gap-2">
+                        <span>#{transaction.id}</span>
+                        <CopyButton
+                          value={String(transaction.id)}
+                          label={`transaction ${transaction.id} id`}
+                        />
+                      </div>
+                    </td>
+                    <td className="py-3 px-4 text-gray-300 font-mono">
+                      {formatAddress(transaction.to, { startChars: 6, endChars: 4 })}
+                    </td>
+                    <td className="py-3 px-4 text-gray-300">{formatXlm(transaction.amount)} XLM</td>
+                    <td className="py-3 px-4 text-gray-400">{formatAbsoluteDate(transaction.createdAt * 1000)}</td>
                   </tr>
-                ) : historyTxs.length === 0 ? (
-                  <tr>
-                    <td colSpan={4} className="text-center text-gray-500 py-8">No transactions yet</td>
-                  </tr>
-                ) : (
-                  historyTxs.map((tx) => (
-                    <tr key={tx.id} className="border-b border-stellar-border/50 hover:bg-gray-800/50 cursor-pointer transition" onClick={() => setSelectedTx(tx)}>
-                      <td className="py-3 px-4 text-white">#{tx.id}</td>
-                      <td className="py-3 px-4 text-gray-300">{tx.topic_1 || "Contract Event"}</td>
-                      <td className="py-3 px-4 text-gray-400">{tx.ledger}</td>
-                      <td className="py-3 px-4 text-gray-400">{new Date(tx.created_at).toLocaleDateString()}</td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
+                ))
+              )}
+            </tbody>
+          </table>
         </div>
       </div>
 
-      {/* Transaction Overlay Drawer */}
       {selectedTx && (
         <>
-          <div className="fixed inset-0 bg-black/50 z-40 transition-opacity" onClick={() => setSelectedTx(null)} />
+          <div
+            className="fixed inset-0 bg-black/50 z-40 transition-opacity"
+            onClick={() => setSelectedTx(null)}
+          />
           <div className="fixed right-0 top-0 h-full w-full max-w-md bg-background border-l border-stellar-border z-50 p-6 shadow-2xl overflow-y-auto transform transition-transform">
             <div className="flex justify-between items-center mb-6">
               <h2 className="text-xl font-bold text-white">Transaction Details</h2>
-              <button onClick={() => setSelectedTx(null)} className="text-gray-400 hover:text-white">
-                ✕
+              <button
+                onClick={() => setSelectedTx(null)}
+                className="text-gray-400 hover:text-white"
+              >
+                X
               </button>
             </div>
-            
+
             <div className="space-y-4">
               <div>
                 <p className="text-xs text-gray-500 uppercase">ID</p>
-                <p className="text-sm text-gray-200 mt-1">#{selectedTx.id}</p>
-              </div>
-              
-              <div>
-                <p className="text-xs text-gray-500 uppercase">Contract</p>
-                <p className="text-sm text-gray-200 mt-1 font-mono break-all">{selectedTx.contract_id}</p>
-              </div>
-
-              <div>
-                <p className="text-xs text-gray-500 uppercase">Topic 1</p>
-                <p className="text-sm text-gray-200 mt-1">{selectedTx.topic_1 || "—"}</p>
-              </div>
-
-               <div>
-                <p className="text-xs text-gray-500 uppercase">Topic 2</p>
-                <p className="text-sm text-gray-200 mt-1 font-mono break-all">{selectedTx.topic_2 || "—"}</p>
+                <div className="mt-1 flex items-center gap-2">
+                  <p className="text-sm text-gray-200">#{selectedTx.id}</p>
+                  <CopyButton
+                    value={String(selectedTx.id)}
+                    label={`transaction ${selectedTx.id} id`}
+                  />
+                </div>
               </div>
 
               <div>
-                <p className="text-xs text-gray-500 uppercase">Event Data</p>
-                <pre className="bg-gray-900 p-3 rounded text-xs text-green-400 mt-1 overflow-x-auto">
-                  {JSON.stringify(selectedTx.event_data, null, 2)}
-                </pre>
+                <p className="text-xs text-gray-500 uppercase">Destination</p>
+                <div className="mt-1 flex items-center gap-2">
+                  <p className="text-sm text-gray-200 font-mono break-all">{selectedTx.to}</p>
+                  <CopyButton
+                    value={selectedTx.to}
+                    label={`transaction ${selectedTx.id} destination address`}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <p className="text-xs text-gray-500 uppercase">Amount</p>
+                <p className="text-sm text-gray-200 mt-1">{formatXlm(selectedTx.amount)} XLM</p>
+              </div>
+
+              <div>
+                <p className="text-xs text-gray-500 uppercase">Memo</p>
+                <p className="text-sm text-gray-200 mt-1">{selectedTx.memo || "-"}</p>
+              </div>
+
+              <div>
+                <p className="text-xs text-gray-500 uppercase">Approvals</p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {selectedTx.approvals.length === 0 ? (
+                    <span className="text-xs text-gray-500">No approvals yet</span>
+                  ) : (
+                    selectedTx.approvals.map((approver) => (
+                      <span
+                        key={`${selectedTx.id}-${approver}`}
+                        className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-gray-300"
+                      >
+                        {formatAddress(approver, { startChars: 4, endChars: 4 })}
+                      </span>
+                    ))
+                  )}
+                </div>
               </div>
 
               <div className="flex gap-4">
                 <div className="flex-1">
-                  <p className="text-xs text-gray-500 uppercase">Ledger</p>
-                  <p className="text-sm text-gray-200 mt-1">{selectedTx.ledger}</p>
+                  <p className="text-xs text-gray-500 uppercase">Status</p>
+                  <p className="text-sm text-gray-200 mt-1">
+                    {selectedTx.executed ? "Executed" : "Pending"}
+                  </p>
                 </div>
                 <div className="flex-1">
-                  <p className="text-xs text-gray-500 uppercase">Time</p>
-                  <p className="text-sm text-gray-200 mt-1">{new Date(selectedTx.created_at).toLocaleString()}</p>
+                  <p className="text-xs text-gray-500 uppercase">Created</p>
+                  <p className="text-sm text-gray-200 mt-1">
+                    {formatAbsoluteDate(selectedTx.createdAt * 1000)}
+                  </p>
                 </div>
               </div>
             </div>
 
             <div className="mt-8 pt-6 border-t border-stellar-border">
-              <button 
-                className="w-full btn-secondary py-3"
-                onClick={() => setSelectedTx(null)}
-              >
-                Close Drawer
+              <button className="w-full btn-secondary py-3" onClick={() => setSelectedTx(null)}>
+                Close
               </button>
             </div>
           </div>
         </>
       )}
+
+      <ConfirmationDialog
+        isOpen={confirmExecuteTxId !== null}
+        title="Confirm Execution"
+        description="This action executes the treasury transaction on-chain and cannot be undone."
+        confirmLabel="Execute Transaction"
+        cancelLabel="Cancel"
+        isConfirming={
+          confirmExecuteTxId !== null &&
+          pendingActions.get(confirmExecuteTxId) === "execute"
+        }
+        onConfirm={runExecute}
+        onCancel={() => setConfirmExecuteTxId(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/ConfirmationDialog.tsx
+++ b/frontend/src/components/ConfirmationDialog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useId } from "react";
+
+interface ConfirmationDialogProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  isConfirming?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmationDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  isConfirming = false,
+  onConfirm,
+  onCancel,
+}: ConfirmationDialogProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isConfirming) {
+        onCancel();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, isConfirming, onCancel]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      role="presentation"
+      onClick={() => {
+        if (!isConfirming) {
+          onCancel();
+        }
+      }}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="w-full max-w-md card"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h3 id={titleId} className="text-lg font-semibold text-white">
+          {title}
+        </h3>
+        <p id={descriptionId} className="text-sm text-gray-300 mt-2">
+          {description}
+        </p>
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            className="btn-secondary text-sm"
+            onClick={onCancel}
+            disabled={isConfirming}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className="btn-primary text-sm"
+            onClick={onConfirm}
+            disabled={isConfirming}
+          >
+            {isConfirming ? "Processing..." : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { copyTextToClipboard } from "@/lib/clipboard";
+
+interface CopyButtonProps {
+  value: string;
+  label: string;
+  className?: string;
+}
+
+export function CopyButton({ value, label, className = "" }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setCopied(false);
+    }, 1500);
+
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      setError(null);
+      await copyTextToClipboard(value);
+      setCopied(true);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Copy failed");
+    }
+  };
+
+  const statusLabel = copied ? "Copied" : "Copy";
+  const ariaLabel = copied
+    ? `${label} copied to clipboard`
+    : `Copy ${label} to clipboard`;
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={ariaLabel}
+      title={error ?? `${statusLabel} ${label}`}
+      className={`text-xs px-2 py-1 rounded-md border border-white/15 bg-white/5 hover:bg-white/10 text-gray-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${className}`}
+    >
+      {error ? "Retry" : statusLabel}
+    </button>
+  );
+}

--- a/frontend/src/components/TreasuryCard.tsx
+++ b/frontend/src/components/TreasuryCard.tsx
@@ -1,28 +1,33 @@
 import { formatAddress, formatXlm } from "@/lib/formatters";
+import { CopyButton } from "@/components/CopyButton";
 
 interface TreasuryCardProps {
   /** Transaction ID */
-  txId?: number;
+  txId: number;
   /** Destination address */
-  to?: string;
+  to: string;
   /** Amount in stroops */
-  amount?: number;
+  amount: bigint;
   /** Transaction memo */
-  memo?: string;
-  /** Number of approvals received */
-  approvals?: number;
+  memo: string;
+  /** Current approver addresses */
+  approvals?: string[];
   /** Required approval threshold */
-  threshold?: number;
+  threshold: number;
   /** Whether the transaction has been executed */
-  executed?: boolean;
+  executed: boolean;
   /**
    * Whether an approval for this transaction is currently in-flight.
    * When true the button shows a pending state immediately (optimistic UI),
    * before the chain confirms the approval.
    */
   isPendingApproval?: boolean;
+  /** Whether execution for this transaction is currently in-flight. */
+  isPendingExecution?: boolean;
   /** Called when the user clicks Approve. Receives the txId. */
   onApprove?: (txId: number) => void;
+  /** Called when the user clicks Execute. Receives the txId. */
+  onExecute?: (txId: number) => void;
 }
 
 /**
@@ -31,68 +36,141 @@ interface TreasuryCardProps {
  * Supports optimistic approval state via `isPendingApproval`.
  */
 export function TreasuryCard({
-  txId = 0,
-  to = "G...",
-  amount = 0,
-  memo = "",
-  approvals = 0,
-  threshold = 1,
-  executed = false,
+  txId,
+  to,
+  amount,
+  memo,
+  approvals = [],
+  threshold,
+  executed,
   isPendingApproval = false,
+  isPendingExecution = false,
   onApprove,
+  onExecute,
 }: TreasuryCardProps) {
+  const approvalCount = approvals.length;
   const statusColor = executed
     ? "text-gray-400"
-    : approvals >= threshold
+    : approvalCount >= threshold
       ? "text-green-400"
       : "text-yellow-400";
 
   const statusText = executed
     ? "Executed"
-    : approvals >= threshold
+    : approvalCount >= threshold
       ? "Ready"
       : "Pending";
 
   const canApprove = !executed && !isPendingApproval && !!onApprove;
+  const canExecute =
+    !executed &&
+    !isPendingExecution &&
+    approvalCount >= threshold &&
+    !!onExecute;
 
   const handleApprove = () => {
     if (canApprove) onApprove(txId);
   };
 
+  const handleExecute = () => {
+    if (canExecute) onExecute(txId);
+  };
+
   return (
-    <div className="card flex justify-between items-center">
-      <div className="flex-1">
+    <div className="card space-y-4">
+      <div className="flex justify-between items-center gap-3">
         <div className="flex items-center space-x-3">
           <span className="text-sm font-mono text-gray-500">#{txId}</span>
+          <CopyButton value={String(txId)} label={`transaction ${txId} id`} />
           <span className={`text-xs font-semibold ${statusColor}`}>
             {statusText}
           </span>
           {isPendingApproval && (
             <span className="text-xs font-semibold text-primary-400 animate-pulse">
-              Approving…
+              Approving...
+            </span>
+          )}
+          {isPendingExecution && (
+            <span className="text-xs font-semibold text-primary-400 animate-pulse">
+              Executing...
             </span>
           )}
         </div>
+        <p className="text-sm text-gray-400">
+          {approvalCount}/{threshold} approvals
+        </p>
+      </div>
+
+      <div className="flex-1">
         <p className="text-white font-semibold mt-1">
           {formatXlm(amount)} XLM → {formatAddress(to, { startChars: 6, endChars: 4 })}
         </p>
         {memo && <p className="text-gray-400 text-sm mt-0.5">{memo}</p>}
       </div>
-      <div className="text-right">
-        <p className="text-sm text-gray-400">
-          {approvals}/{threshold} approvals
-        </p>
-        {!executed && (
+
+      <div className="flex flex-wrap items-center gap-2">
+        {approvals.length === 0 ? (
+          <span className="text-xs text-gray-500">No approvals yet</span>
+        ) : (
+          approvals.map((approver) => (
+            <div
+              key={`${txId}-${approver}`}
+              className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/5 py-1 pr-2 pl-1"
+            >
+              <span
+                aria-hidden="true"
+                className="h-5 w-5 rounded-full bg-primary-500/25 text-[10px] font-semibold text-primary-300 flex items-center justify-center"
+              >
+                {approver.slice(1, 2).toUpperCase()}
+              </span>
+              <span className="text-xs text-gray-300">
+                {formatAddress(approver, { startChars: 4, endChars: 3 })}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+
+      {!executed && (
+        <div className="flex flex-wrap gap-2 justify-end">
           <button
-            className={`btn-primary text-xs mt-2 py-1 px-3 ${
+            className={`btn-primary text-xs py-1 px-3 ${
               isPendingApproval ? "opacity-50 cursor-not-allowed" : ""
             }`}
             disabled={isPendingApproval || !onApprove}
             onClick={handleApprove}
           >
-            {isPendingApproval ? "Approving…" : "Approve"}
+            {isPendingApproval ? "Approving..." : "Approve"}
           </button>
-        )}
+          <button
+            className={`btn-secondary text-xs py-1 px-3 ${
+              !canExecute ? "opacity-50 cursor-not-allowed" : ""
+            }`}
+            disabled={!canExecute}
+            onClick={handleExecute}
+          >
+            {isPendingExecution ? "Executing..." : "Execute"}
+          </button>
+        </div>
+      )}
+      {executed && (
+        <p className="text-xs text-green-400 text-right">
+          Executed on-chain
+        </p>
+      )}
+      {approvalCount < threshold && !executed && (
+        <p className="text-xs text-gray-500 text-right">
+          Needs {threshold - approvalCount} more approval
+          {threshold - approvalCount === 1 ? "" : "s"}.
+        </p>
+      )}
+      {approvalCount >= threshold && !executed && (
+        <p className="text-xs text-green-400 text-right">
+          Threshold met. Ready to execute.
+        </p>
+      )}
+      <div className="text-right">
+        <CopyButton value={to} label={`transaction ${txId} destination address`} />
       </div>
     </div>
   );

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { useFreighter } from "@/hooks/useFreighter";
 import { formatAddress } from "@/lib/formatters";
+import { CopyButton } from "@/components/CopyButton";
 
 export const WalletConnect = () => {
   const { address, isConnecting, connect, disconnect, isFreighterInstalled, error } = useFreighter();
@@ -34,6 +35,11 @@ export const WalletConnect = () => {
         <div className="text-sm font-mono bg-white/5 px-3 py-1.5 rounded-lg border border-white/10 text-stellar-blue">
           {formatAddress(address)}
         </div>
+        <CopyButton
+          value={address}
+          label="wallet address"
+          className="text-[11px]"
+        />
         <button 
           onClick={disconnect}
           className="text-xs text-gray-500 hover:text-white transition-colors"

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -1,215 +1,349 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { nativeToScVal } from "@stellar/stellar-sdk";
 import {
-  buildDepositTx,
-  buildProposeWithdrawalTx,
   buildApproveTx,
+  buildDepositTx,
   buildExecuteTx,
+  buildProposeWithdrawalTx,
   CONTRACT_IDS,
   readContractValue,
   signAndSubmit,
 } from "@/lib/soroban";
+import {
+  decodeBigInt,
+  decodeTreasuryConfig,
+  decodeTreasuryTransaction,
+  type TreasuryConfig,
+  type TreasuryTransaction,
+} from "@/lib/contractData";
+import { classifyError, type AppError } from "@/lib/errors";
+import { createLatestRequestGuard, isAbortError } from "@/lib/requestGuard";
+import { isWalletNetworkMismatch } from "@/lib/network";
 import { useFreighter } from "./useFreighter";
-import { readPublicEnv } from "@/lib/env";
-
-export interface TreasuryConfig {
-  admin: string;
-  threshold: number;
-  signer_count: number;
-  balance: number;
-  tx_count: number;
-}
-
-export interface TreasuryTransaction {
-  id: number;
-  contract_id: string;
-  topic_1: string | null;
-  topic_2: string | null;
-  event_data: any;
-  ledger: number;
-  timestamp: number | null;
-  cursor: string | null;
-  created_at: string;
-}
 
 const REFRESH_INTERVAL = 30_000;
-const API_BASE = readPublicEnv("NEXT_PUBLIC_API_URL") || "http://localhost:3001/api";
+const MAX_VISIBLE_TRANSACTIONS = 20;
+
+type TxAction = "approve" | "execute";
 
 export function useTreasury() {
-  const { address } = useFreighter();
-  const [balance, setBalance] = useState<number>(0);
+  const { address, network } = useFreighter();
+  const [balance, setBalance] = useState<bigint>(0n);
   const [config, setConfig] = useState<TreasuryConfig | null>(null);
   const [transactions, setTransactions] = useState<TreasuryTransaction[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<AppError | null>(null);
+  const [txActions, setTxActions] = useState<ReadonlyMap<number, TxAction>>(
+    new Map(),
+  );
 
-  const getBalance = useCallback(async () => {
-    try {
+  const requestGuardRef = useRef(createLatestRequestGuard());
+
+  const isNetworkMismatch = useMemo(
+    () => isWalletNetworkMismatch(network),
+    [network],
+  );
+
+  const setTxAction = useCallback((txId: number, action: TxAction | null) => {
+    setTxActions((previous) => {
+      const next = new Map(previous);
+      if (action) {
+        next.set(txId, action);
+      } else {
+        next.delete(txId);
+      }
+      return next;
+    });
+  }, []);
+
+  const fetchBalance = useCallback(
+    async (requestId: number, signal: AbortSignal) => {
       const result = await readContractValue(
         CONTRACT_IDS.treasury,
         "get_balance",
-        []
+        [],
+        {
+          decoder: decodeBigInt,
+          signal,
+          sourceAddress: address ?? undefined,
+        },
       );
-      const val = Number(result);
-      setBalance(val);
-      return val;
-    } catch (err: any) {
-      console.warn("Failed to fetch balance, using placeholder", err);
-      // Fallback placeholder logic just so the UI doesn't crash if contract isn't deployed
-      setBalance(1000);
-      return 1000;
-    }
-  }, []);
 
-  const getConfig = useCallback(async () => {
-    try {
+      if (requestGuardRef.current.isCurrent(requestId)) {
+        setBalance(result);
+      }
+
+      return result;
+    },
+    [address],
+  );
+
+  const fetchConfig = useCallback(
+    async (requestId: number, signal: AbortSignal) => {
       const result = await readContractValue(
         CONTRACT_IDS.treasury,
         "get_config",
-        []
+        [],
+        {
+          decoder: decodeTreasuryConfig,
+          signal,
+          sourceAddress: address ?? undefined,
+        },
       );
-      setConfig(result);
-      return result;
-    } catch (err: any) {
-      console.warn("Failed to fetch config, using placeholder", err);
-      setConfig({
-        admin: "G...",
-        threshold: 2,
-        signer_count: 3,
-        balance: 1000,
-        tx_count: 10,
-      });
-      return null;
-    }
-  }, []);
 
-  const fetchTransactions = useCallback(async (page = 1, limit = 10) => {
-    try {
-      setIsLoading(true);
-      const res = await fetch(`${API_BASE}/treasury/transactions?page=${page}&limit=${limit}`);
-      if (!res.ok) throw new Error("Failed to fetch transactions");
-      const data = await res.json();
-      setTransactions(Array.isArray(data) ? data : []);
-      return data;
-    } catch (err: any) {
-      setError(err.message || "Failed to fetch transactions");
-      // Fallback dummy data for UI testing (since backend might not be fully seeded)
-      setTransactions([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+      if (requestGuardRef.current.isCurrent(requestId)) {
+        setConfig(result);
+        setBalance(result.balance);
+      }
+
+      return result;
+    },
+    [address],
+  );
+
+  const fetchTransaction = useCallback(
+    async (transactionId: number, signal: AbortSignal) => {
+      return readContractValue(
+        CONTRACT_IDS.treasury,
+        "get_transaction",
+        [nativeToScVal(transactionId, { type: "u64" })],
+        {
+          decoder: decodeTreasuryTransaction,
+          signal,
+          sourceAddress: address ?? undefined,
+        },
+      );
+    },
+    [address],
+  );
+
+  const fetchTransactions = useCallback(
+    async (requestId: number, signal: AbortSignal, txCount: number) => {
+      if (txCount <= 0) {
+        if (requestGuardRef.current.isCurrent(requestId)) {
+          setTransactions([]);
+        }
+        return [];
+      }
+
+      const firstId = Math.max(1, txCount - MAX_VISIBLE_TRANSACTIONS + 1);
+      const ids = Array.from(
+        { length: txCount - firstId + 1 },
+        (_, index) => txCount - index,
+      );
+
+      const results = await Promise.all(
+        ids.map((transactionId) => fetchTransaction(transactionId, signal)),
+      );
+
+      if (requestGuardRef.current.isCurrent(requestId)) {
+        setTransactions(results);
+      }
+
+      return results;
+    },
+    [fetchTransaction],
+  );
 
   const refresh = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      await Promise.all([getBalance(), getConfig(), fetchTransactions()]);
-    } catch {
-      // Errors handled
-    } finally {
-      setIsLoading(false);
-    }
-  }, [getBalance, getConfig, fetchTransactions]);
+    const request = requestGuardRef.current.begin();
 
-  const deposit = async (amount: number): Promise<void> => {
-    if (!address) throw new Error("Wallet not connected");
-    setError(null);
-    setIsLoading(true);
-    try {
-      const tx = await buildDepositTx(CONTRACT_IDS.treasury, address, amount);
-      const built = tx.build();
-      await signAndSubmit(built);
-      await getBalance();
-    } catch (err: any) {
-      setError(err.message || "Deposit failed");
-      throw err;
-    } finally {
-      setIsLoading(false);
+    if (requestGuardRef.current.isCurrent(request.id)) {
+      setIsLoading(true);
+      setError(null);
     }
-  };
 
-  const proposeWithdrawal = async (
-    to: string,
-    amount: number,
-    memo: string
-  ): Promise<void> => {
-    if (!address) throw new Error("Wallet not connected");
-    setError(null);
-    setIsLoading(true);
     try {
-      const tx = await buildProposeWithdrawalTx(
-        CONTRACT_IDS.treasury,
-        address,
-        to,
-        amount,
-        memo
+      const [currentBalance, currentConfig] = await Promise.all([
+        fetchBalance(request.id, request.signal),
+        fetchConfig(request.id, request.signal),
+      ]);
+
+      await fetchTransactions(request.id, request.signal, currentConfig.txCount);
+
+      if (requestGuardRef.current.isCurrent(request.id)) {
+        setBalance(currentConfig.balance ?? currentBalance);
+      }
+    } catch (err: unknown) {
+      if (!isAbortError(err) && requestGuardRef.current.isCurrent(request.id)) {
+        setError(classifyError(err));
+      }
+    } finally {
+      if (requestGuardRef.current.isCurrent(request.id)) {
+        setIsLoading(false);
+      }
+    }
+  }, [fetchBalance, fetchConfig, fetchTransactions]);
+
+  const assertWalletReady = useCallback(() => {
+    if (!address) {
+      throw new Error("Wallet not connected");
+    }
+
+    if (isNetworkMismatch) {
+      throw new Error("Wallet network mismatch");
+    }
+  }, [address, isNetworkMismatch]);
+
+  const deposit = useCallback(
+    async (amount: number): Promise<void> => {
+      assertWalletReady();
+      const walletAddress = address as string;
+      setError(null);
+
+      try {
+        const txBuilder = await buildDepositTx(
+          CONTRACT_IDS.treasury,
+          walletAddress,
+          amount,
+        );
+        await signAndSubmit(txBuilder.build());
+        await refresh();
+      } catch (err: unknown) {
+        const appError = classifyError(err);
+        setError(appError);
+        throw appError;
+      }
+    },
+    [address, assertWalletReady, refresh],
+  );
+
+  const proposeWithdrawal = useCallback(
+    async (to: string, amount: number, memo: string): Promise<void> => {
+      assertWalletReady();
+      const walletAddress = address as string;
+      setError(null);
+
+      try {
+        const txBuilder = await buildProposeWithdrawalTx(
+          CONTRACT_IDS.treasury,
+          walletAddress,
+          to,
+          amount,
+          memo,
+        );
+        await signAndSubmit(txBuilder.build());
+        await refresh();
+      } catch (err: unknown) {
+        const appError = classifyError(err);
+        setError(appError);
+        throw appError;
+      }
+    },
+    [address, assertWalletReady, refresh],
+  );
+
+  const approve = useCallback(
+    async (txId: number): Promise<void> => {
+      assertWalletReady();
+      const walletAddress = address as string;
+      setError(null);
+      setTxAction(txId, "approve");
+
+      const snapshot = transactions;
+      setTransactions((current) =>
+        current.map((transaction) => {
+          if (
+            transaction.id !== txId ||
+            transaction.approvals.includes(walletAddress)
+          ) {
+            return transaction;
+          }
+
+          return {
+            ...transaction,
+            approvals: [...transaction.approvals, walletAddress],
+          };
+        }),
       );
-      const built = tx.build();
-      await signAndSubmit(built);
-      await getConfig();
-    } catch (err: any) {
-      setError(err.message || "Propose withdrawal failed");
-      throw err;
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
-  const approve = async (txId: number): Promise<void> => {
-    if (!address) throw new Error("Wallet not connected");
-    setError(null);
-    setIsLoading(true);
-    try {
-      const tx = await buildApproveTx(CONTRACT_IDS.treasury, address, txId);
-      const built = tx.build();
-      await signAndSubmit(built);
-      await refresh();
-    } catch (err: any) {
-      setError(err.message || "Approve failed");
-      throw err;
-    } finally {
-      setIsLoading(false);
-    }
-  };
+      try {
+        const txBuilder = await buildApproveTx(
+          CONTRACT_IDS.treasury,
+          walletAddress,
+          txId,
+        );
+        await signAndSubmit(txBuilder.build());
+        await refresh();
+      } catch (err: unknown) {
+        setTransactions(snapshot);
+        const appError = classifyError(err);
+        setError(appError);
+        throw appError;
+      } finally {
+        setTxAction(txId, null);
+      }
+    },
+    [address, assertWalletReady, refresh, setTxAction, transactions],
+  );
 
-  const execute = async (txId: number): Promise<void> => {
-    if (!address) throw new Error("Wallet not connected");
+  const execute = useCallback(
+    async (txId: number): Promise<void> => {
+      assertWalletReady();
+      const walletAddress = address as string;
+      setError(null);
+      setTxAction(txId, "execute");
+
+      try {
+        const txBuilder = await buildExecuteTx(
+          CONTRACT_IDS.treasury,
+          walletAddress,
+          txId,
+        );
+        await signAndSubmit(txBuilder.build());
+        await refresh();
+      } catch (err: unknown) {
+        const appError = classifyError(err);
+        setError(appError);
+        throw appError;
+      } finally {
+        setTxAction(txId, null);
+      }
+    },
+    [address, assertWalletReady, refresh, setTxAction],
+  );
+
+  const clearError = useCallback(() => {
     setError(null);
-    setIsLoading(true);
-    try {
-      const tx = await buildExecuteTx(CONTRACT_IDS.treasury, address, txId);
-      const built = tx.build();
-      await signAndSubmit(built);
-      await refresh();
-    } catch (err: any) {
-      setError(err.message || "Execute failed");
-      throw err;
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  }, []);
 
   useEffect(() => {
+    const requestGuard = requestGuardRef.current;
     refresh();
-    const interval = setInterval(refresh, REFRESH_INTERVAL);
-    return () => clearInterval(interval);
+
+    const interval = setInterval(() => {
+      refresh();
+    }, REFRESH_INTERVAL);
+
+    return () => {
+      clearInterval(interval);
+      requestGuard.cancel("Treasury refresh cancelled.");
+    };
   }, [refresh]);
 
+  useEffect(() => {
+    const requestGuard = requestGuardRef.current;
+    return () => {
+      requestGuard.dispose();
+    };
+  }, []);
+
   return {
+    address,
     balance,
     config,
     transactions,
     isLoading,
     error,
-    getBalance,
-    getConfig,
-    fetchTransactions,
+    isNetworkMismatch,
+    pendingActions: txActions,
     deposit,
     proposeWithdrawal,
     approve,
     execute,
     refresh,
+    clearError,
   };
 }

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,25 @@
+export async function copyTextToClipboard(value: string): Promise<void> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+
+  if (typeof document === "undefined") {
+    throw new Error("Clipboard is not available in this environment.");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  const copied = document.execCommand("copy");
+  document.body.removeChild(textarea);
+
+  if (!copied) {
+    throw new Error("Unable to copy text to clipboard.");
+  }
+}

--- a/frontend/src/lib/network.ts
+++ b/frontend/src/lib/network.ts
@@ -47,6 +47,9 @@ export const HORIZON_URL = ACTIVE_NETWORK.horizonUrl;
 
 /** Network passphrase for the active network. */
 export const NETWORK_PASSPHRASE = ACTIVE_NETWORK.networkPassphrase;
+export const ACTIVE_NETWORK_KEY = Object.entries(NETWORKS).find(
+  ([, network]) => network.networkPassphrase === NETWORK_PASSPHRASE,
+)?.[0] as keyof typeof NETWORKS | undefined;
 
 // ============================================================================
 // Helpers
@@ -75,4 +78,47 @@ export async function fundAccount(address: string): Promise<boolean> {
     console.error("Failed to fund account:", err);
     return false;
   }
+}
+
+function normalizeWalletNetwork(
+  value: string,
+): "testnet" | "futurenet" | "mainnet" | null {
+  const normalized = value.trim().toLowerCase();
+
+  if (
+    normalized.includes("testnet") ||
+    normalized.includes("test sdf network ; september 2015")
+  ) {
+    return "testnet";
+  }
+
+  if (
+    normalized.includes("futurenet") ||
+    normalized.includes("future network ; october 2022")
+  ) {
+    return "futurenet";
+  }
+
+  if (
+    normalized.includes("mainnet") ||
+    normalized.includes("public") ||
+    normalized.includes("public global stellar network ; september 2015")
+  ) {
+    return "mainnet";
+  }
+
+  return null;
+}
+
+export function isWalletNetworkMismatch(walletNetwork: string | null): boolean {
+  if (!walletNetwork || !ACTIVE_NETWORK_KEY) {
+    return false;
+  }
+
+  const walletNetworkKey = normalizeWalletNetwork(walletNetwork);
+  if (!walletNetworkKey) {
+    return false;
+  }
+
+  return walletNetworkKey !== ACTIVE_NETWORK_KEY;
 }


### PR DESCRIPTION
## Description
Implemented the treasury dashboard and shared interaction UX upgrades to use live typed on-chain data, production-ready transaction actions, and accessible copy/confirmation patterns across treasury and wallet surfaces.

Closes #124
Closes #116
Closes #131
Closes #122

## Changes proposed

### What were you told to do?
Implement the FE-141, FE-133, FE-148, and FE-139 frontend issues together by wiring treasury to live contracts, handling wallet/network state and retries, adding copy-to-clipboard interactions, showing per-transaction approval avatars/chips, and introducing a confirmation dialog for irreversible actions.

### What did I do?
#### Treasury Data + Action Wiring
- Refactored `useTreasury` to consume typed on-chain contract reads for `get_balance`, `get_config`, and `get_transaction`.
- Added explicit wallet/network guard checks before signing actions, structured error handling, and retry-friendly refresh behavior.
- Added optimistic approval state and per-transaction action loading states for approve/execute flows.

#### Treasury UI + UX States
- Rebuilt `/treasury` page to render live balance/config/transactions, pending vs executed sections, and actionable cards.
- Added disconnected wallet and network mismatch states, plus clear retry/dismiss controls for recoverable errors.
- Added execution confirmation modal before irreversible execute calls.

#### Shared Interaction Components
- Added reusable `CopyButton` and clipboard utility with keyboard-accessible semantics and visible copy feedback.
- Integrated copy actions for wallet address, treasury admin address, transaction IDs, and destination addresses.
- Extended `TreasuryCard` with approval avatar/address chips and execute readiness feedback.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm run lint` passed (warnings only from pre-existing files: `layout.tsx` font warning and `useGovernance` ref cleanup warnings).
- `npm run test` passed (20/20 tests).
- `npm run build` fails due a pre-existing unrelated type error in `frontend/src/app/template.tsx:16` (`transition.type = "linear"` not assignable).
