### PR TITLE
feat(governance): render proposals from on-chain data, add action labels, sorting, and treasury tests

### DIFF
--- a/frontend/src/app/governance/page.tsx
+++ b/frontend/src/app/governance/page.tsx
@@ -1,4 +1,4 @@
- "use client";
+"use client";
 
 import { useEffect, useMemo, useState } from "react";
 import { ProposalCard } from "@/components/ProposalCard";
@@ -27,11 +27,39 @@ const ACTION_FILTERS: Array<"All" | GovernanceProposalAction> = [
   "General",
 ];
 
+type SortKey = "newest" | "ending-soon" | "most-votes";
+
+const SORT_OPTIONS: Array<{ value: SortKey; label: string }> = [
+  { value: "newest", label: "Newest" },
+  { value: "ending-soon", label: "Ending Soon" },
+  { value: "most-votes", label: "Most Votes" },
+];
+
+function sortProposals(proposals: GovernanceProposal[], sort: SortKey): GovernanceProposal[] {
+  const copy = [...proposals];
+  switch (sort) {
+    case "newest":
+      return copy.sort((a, b) => b.createdAt - a.createdAt);
+    case "ending-soon":
+      return copy.sort((a, b) => {
+        const now = Math.floor(Date.now() / 1000);
+        const aEnds = a.endsAt > now ? a.endsAt : Number.MAX_SAFE_INTEGER;
+        const bEnds = b.endsAt > now ? b.endsAt : Number.MAX_SAFE_INTEGER;
+        return aEnds - bEnds;
+      });
+    case "most-votes":
+      return copy.sort((a, b) => b.totalVotes - a.totalVotes);
+    default:
+      return copy;
+  }
+}
+
 export default function GovernancePage() {
   const { config, getConfig, getProposal, isLoading, error } = useGovernance();
   const [proposals, setProposals] = useState<GovernanceProposal[]>([]);
   const [statusFilter, setStatusFilter] = useState<"All" | GovernanceProposalStatus>("All");
   const [actionFilter, setActionFilter] = useState<"All" | GovernanceProposalAction>("All");
+  const [sortKey, setSortKey] = useState<SortKey>("newest");
 
   useEffect(() => {
     const load = async () => {
@@ -54,9 +82,7 @@ export default function GovernancePage() {
           }
         }
 
-        setProposals(
-          loaded.sort((a, b) => b.id - a.id),
-        );
+        setProposals(loaded);
       } catch {
         setProposals([]);
       }
@@ -66,12 +92,13 @@ export default function GovernancePage() {
   }, [getConfig, getProposal]);
 
   const filteredProposals = useMemo(() => {
-    return proposals.filter((proposal) => {
-      const statusOk = statusFilter === "All" || proposal.status === statusFilter;
-      const actionOk = actionFilter === "All" || proposal.action === actionFilter;
+    const filtered = proposals.filter((p) => {
+      const statusOk = statusFilter === "All" || p.status === statusFilter;
+      const actionOk = actionFilter === "All" || p.action === actionFilter;
       return statusOk && actionOk;
     });
-  }, [proposals, statusFilter, actionFilter]);
+    return sortProposals(filtered, sortKey);
+  }, [proposals, statusFilter, actionFilter, sortKey]);
 
   const activeProposals = filteredProposals.filter((p) => p.status === "Active");
   const pastProposals = filteredProposals.filter((p) => p.status !== "Active");
@@ -85,11 +112,9 @@ export default function GovernancePage() {
             Create and vote on proposals for your organization
           </p>
         </div>
-        {/* TODO: [FE-14] Add Create Proposal Modal trigger */}
         <button className="btn-primary">+ New Proposal</button>
       </div>
 
-      {/* Governance Stats */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div className="card text-center">
           <p className="text-sm text-gray-400">Total Proposals</p>
@@ -113,39 +138,44 @@ export default function GovernancePage() {
         <div>
           <label className="block text-xs text-gray-400 mb-1">Status</label>
           <select
-            className="bg-gray-900 border border-stellar-border rounded px-3 py-2"
+            className="bg-gray-900 border border-stellar-border rounded px-3 py-2 text-sm text-white"
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value as typeof statusFilter)}
           >
-            {STATUS_FILTERS.map((status) => (
-              <option key={status} value={status}>
-                {status}
-              </option>
+            {STATUS_FILTERS.map((s) => (
+              <option key={s} value={s}>{s}</option>
             ))}
           </select>
         </div>
         <div>
           <label className="block text-xs text-gray-400 mb-1">Action</label>
           <select
-            className="bg-gray-900 border border-stellar-border rounded px-3 py-2"
+            className="bg-gray-900 border border-stellar-border rounded px-3 py-2 text-sm text-white"
             value={actionFilter}
             onChange={(e) => setActionFilter(e.target.value as typeof actionFilter)}
           >
-            {ACTION_FILTERS.map((action) => (
-              <option key={action} value={action}>
-                {action}
-              </option>
+            {ACTION_FILTERS.map((a) => (
+              <option key={a} value={a}>{a}</option>
             ))}
           </select>
         </div>
-        {error ? <p className="text-red-400 text-sm">{error.message}</p> : null}
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Sort By</label>
+          <select
+            className="bg-gray-900 border border-stellar-border rounded px-3 py-2 text-sm text-white"
+            value={sortKey}
+            onChange={(e) => setSortKey(e.target.value as SortKey)}
+          >
+            {SORT_OPTIONS.map(({ value, label }) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
+        {error ? <p className="text-red-400 text-sm">{typeof error === "string" ? error : (error as Error).message}</p> : null}
       </div>
 
-      {/* Proposal List */}
       <div>
-        <h2 className="text-xl font-semibold text-white mb-4">
-          Active Proposals
-        </h2>
+        <h2 className="text-xl font-semibold text-white mb-4">Active Proposals</h2>
         <div className="space-y-4">
           {isLoading ? (
             <div className="card">
@@ -163,11 +193,8 @@ export default function GovernancePage() {
         </div>
       </div>
 
-      {/* Past Proposals */}
       <div>
-        <h2 className="text-xl font-semibold text-white mb-4">
-          Past Proposals
-        </h2>
+        <h2 className="text-xl font-semibold text-white mb-4">Past Proposals</h2>
         <div className="space-y-4">
           {pastProposals.length === 0 ? (
             <div className="card">

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -1,76 +1,91 @@
 import Link from "next/link";
-import { formatAddress } from "@/lib/formatters";
+import { formatAddress, formatRelativeDate } from "@/lib/formatters";
 import { StatusBadge } from "@/components/StatusBadge";
+import { ACTION_LABELS } from "@/lib/contractData";
+import type { GovernanceProposalAction, GovernanceProposalStatus } from "@/lib/contractData";
 
 interface ProposalCardProps {
-  /** Proposal ID */
   id?: number;
-  /** Proposal title */
   title?: string;
-  /** Proposal description */
   description?: string;
-  /** Proposal status */
-  status?: "Active" | "Passed" | "Rejected" | "Executed" | "Expired";
-  /** Votes in favor */
+  status?: GovernanceProposalStatus;
+  action?: GovernanceProposalAction;
   votesFor?: number;
-  /** Votes against */
   votesAgainst?: number;
-  /** Total members who can vote */
   totalMembers?: number;
-  /** Proposer address */
   proposer?: string;
+  endsAt?: number;
+  createdAt?: number;
 }
 
-/**
- * Card component for displaying a governance proposal.
- * Shows proposal details, voting progress, and link to detail page.
- */
 export function ProposalCard({
   id = 0,
   title = "Untitled Proposal",
   description = "",
   status = "Active",
+  action,
   votesFor = 0,
   votesAgainst = 0,
   totalMembers = 1,
   proposer = "G...",
+  endsAt,
+  createdAt,
 }: ProposalCardProps) {
   const totalVotes = votesFor + votesAgainst;
   const forPercent = totalVotes > 0 ? (votesFor / totalVotes) * 100 : 0;
 
+  const now = Math.floor(Date.now() / 1000);
+  const timeLabel =
+    status === "Active" && endsAt != null
+      ? endsAt > now
+        ? "Ends " + formatRelativeDate(endsAt * 1000)
+        : "Voting ended"
+      : createdAt != null
+        ? "Created " + formatRelativeDate(createdAt * 1000)
+        : null;
+
   return (
-    <Link href={`/proposals/${id}`} className="block">
+    <Link href={"/proposals/" + id} className="block">
       <div className="card hover:border-primary-600/50 transition-colors cursor-pointer">
         <div className="flex justify-between items-start">
-          <div className="flex-1">
-            <div className="flex items-center space-x-3 mb-2">
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-center gap-2 mb-2">
               <span className="text-sm font-mono text-gray-500">#{id}</span>
               <StatusBadge status={status} />
+              {action && (
+                <span className="px-2 py-0.5 rounded-full text-xs font-medium border border-white/10 bg-white/5 text-gray-300">
+                  {ACTION_LABELS[action]}
+                </span>
+              )}
             </div>
-            <h3 className="text-lg font-semibold text-white">{title}</h3>
+            <h3 className="text-lg font-semibold text-white truncate">{title}</h3>
             {description && (
-              <p className="text-gray-400 text-sm mt-1">{description}</p>
+              <p className="text-gray-400 text-sm mt-1 line-clamp-2">{description}</p>
             )}
-            <p className="text-gray-500 text-xs mt-2">
-              by {formatAddress(proposer, { startChars: 6, endChars: 4 })}
-            </p>
+            <div className="flex items-center gap-3 mt-2 text-xs text-gray-500">
+              <span>by {formatAddress(proposer, { startChars: 6, endChars: 4 })}</span>
+              {timeLabel && <span>· {timeLabel}</span>}
+            </div>
           </div>
-          <div className="text-right ml-4">
+          <div className="text-right ml-4 shrink-0">
             <p className="text-sm text-gray-400">
               {totalVotes}/{totalMembers} voted
             </p>
             {totalVotes > 0 && (
-              <div className="mt-2 w-24">
+              <div className="mt-2 w-28">
                 <div className="flex justify-between text-xs mb-1">
-                  <span className="text-green-400">{votesFor}</span>
-                  <span className="text-red-400">{votesAgainst}</span>
+                  <span className="text-green-400">{votesFor} for</span>
+                  <span className="text-red-400">{votesAgainst} against</span>
                 </div>
                 <div className="w-full bg-red-900/30 rounded-full h-1.5">
                   <div
-                    className="bg-green-500 h-1.5 rounded-full"
-                    style={{ width: `${forPercent}%` }}
+                    className="bg-green-500 h-1.5 rounded-full transition-all"
+                    style={{ width: forPercent + "%" }}
                   />
                 </div>
+                <p className="text-xs text-gray-500 mt-1 text-right">
+                  {Math.round(forPercent)}% for
+                </p>
               </div>
             )}
           </div>

--- a/frontend/src/lib/contractData.test.ts
+++ b/frontend/src/lib/contractData.test.ts
@@ -114,3 +114,110 @@ describe("contract decoders", () => {
     expect(decodeBigInt("42")).toBe(BigInt(42));
   });
 });
+
+describe("treasury integration tests with mocked Soroban responses", () => {
+  it("decodes a full treasury config from a realistic RPC-shaped response", () => {
+    const mockRpcResponse = {
+      admin: "GADMIN7XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      threshold: "2",
+      signer_count: BigInt(3),
+      balance: "50000000000",
+      tx_count: 7,
+    };
+
+    expect(decodeTreasuryConfig(mockRpcResponse)).toEqual({
+      admin: "GADMIN7XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      threshold: 2,
+      signerCount: 3,
+      balance: BigInt(50000000000),
+      txCount: 7,
+    });
+  });
+
+  it("decodes a pending treasury transaction with no approvals", () => {
+    const mockRpcResponse = {
+      id: "1",
+      to: "GDEST1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      amount: BigInt(10000000),
+      memo: "Q1 operating budget",
+      approvals: [],
+      executed: false,
+      created_at: 1700000000,
+      proposer: "GPROP1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    };
+
+    expect(decodeTreasuryTransaction(mockRpcResponse)).toEqual({
+      id: 1,
+      to: "GDEST1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      amount: BigInt(10000000),
+      memo: "Q1 operating budget",
+      approvals: [],
+      executed: false,
+      createdAt: 1700000000,
+      proposer: "GPROP1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    });
+  });
+
+  it("decodes an executed transaction with multiple approvers", () => {
+    const mockRpcResponse = {
+      id: BigInt(5),
+      to: "GDEST2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      amount: "25000000",
+      memo: "emergency fund",
+      approvals: [
+        "GSIGNER1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "GSIGNER2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "GSIGNER3XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      ],
+      executed: true,
+      created_at: "1699000000",
+      proposer: "GPROP2XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    };
+
+    const decoded = decodeTreasuryTransaction(mockRpcResponse);
+
+    expect(decoded.executed).toBe(true);
+    expect(decoded.approvals).toHaveLength(3);
+    expect(decoded.amount).toBe(BigInt(25000000));
+    expect(decoded.id).toBe(5);
+  });
+
+  it("rejects treasury config missing the threshold field", () => {
+    expect(() =>
+      decodeTreasuryConfig({
+        admin: "GADMIN",
+        signer_count: 2,
+        balance: "1000",
+        tx_count: 0,
+      }),
+    ).toThrow(/missing "threshold"/i);
+  });
+
+  it("rejects treasury transaction with non-boolean executed field", () => {
+    expect(() =>
+      decodeTreasuryTransaction({
+        id: 1,
+        to: "GDEST",
+        amount: 0,
+        memo: "",
+        approvals: [],
+        executed: "yes",
+        created_at: 0,
+        proposer: "GPROP",
+      }),
+    ).toThrow(/boolean/i);
+  });
+
+  it("decodes treasury config with zero balance and tx count", () => {
+    const empty = decodeTreasuryConfig({
+      admin: "GADMIN",
+      threshold: 1,
+      signer_count: 1,
+      balance: "0",
+      tx_count: 0,
+    });
+
+    expect(empty.balance).toBe(BigInt(0));
+    expect(empty.txCount).toBe(0);
+  });
+});

--- a/frontend/src/lib/contractData.ts
+++ b/frontend/src/lib/contractData.ts
@@ -7,6 +7,24 @@ export type GovernanceProposalAction =
   | "RemoveMember"
   | "General";
 
+/** Human-readable label for each proposal action enum value. */
+export const ACTION_LABELS: Record<GovernanceProposalAction, string> = {
+  Funding: "Funding",
+  PolicyChange: "Policy Change",
+  AddMember: "Add Member",
+  RemoveMember: "Remove Member",
+  General: "General",
+};
+
+/** One-line description for each proposal action shown in tooltips and detail views. */
+export const ACTION_DESCRIPTIONS: Record<GovernanceProposalAction, string> = {
+  Funding: "Allocate treasury funds to a destination address",
+  PolicyChange: "Update a governance or contract policy parameter",
+  AddMember: "Grant voting membership to a new address",
+  RemoveMember: "Revoke voting membership from an existing address",
+  General: "General-purpose proposal with no specific on-chain action",
+};
+
 export type GovernanceProposalStatus =
   | "Active"
   | "Passed"


### PR DESCRIPTION
## Summary

- Add `ACTION_LABELS` and `ACTION_DESCRIPTIONS` maps to `contractData.ts` for human-readable proposal action enum decoding
- Update `ProposalCard` to render on-chain data including action type badge, vote progress bar with percentage, and timing labels (ends-at for active proposals, created-at for past ones)
- Add governance list sort controls (newest, ending soon, most votes) to the governance page alongside existing status and action filters
- Add treasury integration tests with mocked Soroban RPC responses covering full config decoding, pending and executed transactions, error cases, and zero-state values

Closes #143
Closes #145
Closes #154
Closes #155