### PR TITLE
feat: toast system, form error summary, skeleton loaders, and data table (#112 #113 #114 #115)

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { FreighterProvider } from "@/context/FreighterProvider";
 import { WalletConnect } from "@/components/WalletConnect";
 import { DiagnosticsPanel } from "@/components/DiagnosticsPanel";
+import { ToastContainer } from "@/components/Toast";
 
 
 export const metadata: Metadata = {
@@ -91,6 +92,7 @@ export default function RootLayout({
             </div>
           </footer>
           <DiagnosticsPanel />
+          <ToastContainer />
         </FreighterProvider>
       </body>
     </html>

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+import React, { useState, useMemo, useId, useCallback } from "react";
+import {
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+  Search,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+import { cn } from "./Shimmer";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface Column<T> {
+  /** Unique key, used for sorting. */
+  key: keyof T & string;
+  /** Column header label. */
+  header: string;
+  /** Custom cell renderer. Defaults to `String(row[key])`. */
+  render?: (value: T[keyof T], row: T) => React.ReactNode;
+  /** Whether this column is sortable. Defaults to true. */
+  sortable?: boolean;
+  /** Tailwind class(es) to apply to all cells in this column. */
+  cellClassName?: string;
+  /** Tailwind class(es) for the header cell only. */
+  headerClassName?: string;
+}
+
+type SortDir = "asc" | "desc" | "none";
+
+interface SortState {
+  key: string;
+  dir: SortDir;
+}
+
+const PAGE_SIZE_OPTIONS = [5, 10, 20, 50] as const;
+
+export interface DataTableProps<T> {
+  /** Column definitions. */
+  columns: Column<T>[];
+  /** Row data. */
+  data: T[];
+  /** Unique row identifier. */
+  rowKey: keyof T;
+  /** Show the search/filter bar. Default true. */
+  searchable?: boolean;
+  /** Keys to search across. Defaults to all string/number columns. */
+  searchKeys?: (keyof T)[];
+  /** Placeholder for the search input. */
+  searchPlaceholder?: string;
+  /** Initial page size. */
+  defaultPageSize?: number;
+  /** Accessible label for the table. */
+  caption?: string;
+  className?: string;
+  /** Rendered when the filtered result set is empty. */
+  emptyState?: React.ReactNode;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function sortData<T>(data: T[], sort: SortState): T[] {
+  if (sort.dir === "none") return data;
+  return [...data].sort((a, b) => {
+    const av = (a as Record<string, unknown>)[sort.key];
+    const bv = (b as Record<string, unknown>)[sort.key];
+    let cmp = 0;
+    if (typeof av === "number" && typeof bv === "number") {
+      cmp = av - bv;
+    } else {
+      cmp = String(av ?? "").localeCompare(String(bv ?? ""), undefined, {
+        numeric: true,
+        sensitivity: "base",
+      });
+    }
+    return sort.dir === "asc" ? cmp : -cmp;
+  });
+}
+
+function filterData<T>(data: T[], query: string, keys: (keyof T)[]): T[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return data;
+  return data.filter((row) =>
+    keys.some((k) => String((row as Record<string, unknown>)[k as string] ?? "").toLowerCase().includes(q))
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function DataTable<T extends object>({
+  columns,
+  data,
+  rowKey,
+  searchable = true,
+  searchKeys,
+  searchPlaceholder = "Search…",
+  defaultPageSize = 10,
+  caption,
+  className,
+  emptyState,
+}: DataTableProps<T>) {
+  const tableId = useId();
+  const captionId = `${tableId}-caption`;
+
+  const effectiveSearchKeys =
+    searchKeys ??
+    (columns
+      .filter((c) => c.sortable !== false)
+      .map((c) => c.key) as (keyof T)[]);
+
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortState>({ key: "", dir: "none" });
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(defaultPageSize);
+
+  const filtered = useMemo(
+    () => filterData(data, query, effectiveSearchKeys),
+    [data, query, effectiveSearchKeys]
+  );
+
+  const sorted = useMemo(() => sortData(filtered, sort), [filtered, sort]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+
+  const paginated = useMemo(() => {
+    const start = (safePage - 1) * pageSize;
+    return sorted.slice(start, start + pageSize);
+  }, [sorted, safePage, pageSize]);
+
+  const handleSort = useCallback(
+    (key: string) => {
+      setSort((prev) => {
+        if (prev.key !== key) return { key, dir: "asc" };
+        if (prev.dir === "asc") return { key, dir: "desc" };
+        return { key: "", dir: "none" };
+      });
+      setPage(1);
+    },
+    []
+  );
+
+  const handleSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+    setPage(1);
+  }, []);
+
+  const SortIcon = ({ colKey }: { colKey: string }) => {
+    if (sort.key !== colKey)
+      return <ChevronsUpDown size={13} className="opacity-40" />;
+    return sort.dir === "asc" ? (
+      <ChevronUp size={13} className="text-primary-400" />
+    ) : (
+      <ChevronDown size={13} className="text-primary-400" />
+    );
+  };
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {/* Search bar */}
+      {searchable && (
+        <div className="relative">
+          <Search
+            size={15}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none"
+            aria-hidden="true"
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={handleSearch}
+            placeholder={searchPlaceholder}
+            aria-label={`Filter ${caption ?? "table"}`}
+            className={cn(
+              "w-full pl-9 pr-4 py-2.5 rounded-xl text-sm",
+              "bg-white/5 border border-white/10",
+              "text-gray-200 placeholder:text-gray-600",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/60",
+              "transition-colors"
+            )}
+          />
+        </div>
+      )}
+
+      {/* Table wrapper */}
+      <div className="card overflow-x-auto p-0 rounded-2xl">
+        <table
+          className="w-full text-sm"
+          aria-labelledby={caption ? captionId : undefined}
+        >
+          {caption && (
+            <caption id={captionId} className="sr-only">
+              {caption}
+            </caption>
+          )}
+
+          <thead>
+            <tr className="border-b border-white/5">
+              {columns.map((col) => {
+                const isSorted = sort.key === col.key;
+                const sortable = col.sortable !== false;
+                return (
+                  <th
+                    key={col.key}
+                    scope="col"
+                    className={cn(
+                      "px-5 py-3 text-left text-xs font-semibold text-gray-400 uppercase tracking-wide whitespace-nowrap",
+                      sortable && "cursor-pointer select-none hover:text-white transition-colors",
+                      isSorted && "text-primary-400",
+                      col.headerClassName
+                    )}
+                    onClick={sortable ? () => handleSort(col.key) : undefined}
+                    aria-sort={
+                      isSorted
+                        ? sort.dir === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : sortable
+                          ? "none"
+                          : undefined
+                    }
+                  >
+                    <span className="inline-flex items-center gap-1.5">
+                      {col.header}
+                      {sortable && <SortIcon colKey={col.key} />}
+                    </span>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody>
+            {paginated.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  className="px-5 py-12 text-center text-sm text-gray-500"
+                >
+                  {emptyState ?? (
+                    <span>
+                      {query ? `No results for "${query}"` : "No data available"}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ) : (
+              paginated.map((row, i) => (
+                <tr
+                  key={String((row as Record<string, unknown>)[rowKey as string])}
+                  className={cn(
+                    "border-b border-white/5 last:border-0 transition-colors",
+                    "hover:bg-white/3",
+                    i % 2 === 0 ? "" : "bg-white/1"
+                  )}
+                >
+                  {columns.map((col) => (
+                    <td
+                      key={col.key}
+                      className={cn(
+                        "px-5 py-4 text-gray-300",
+                        col.cellClassName
+                      )}
+                    >
+                      {col.render
+                        ? col.render(
+                            (row as Record<string, unknown>)[col.key] as T[keyof T],
+                            row
+                          )
+                        : String(
+                            (row as Record<string, unknown>)[col.key] ?? ""
+                          )}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination controls */}
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-3 text-sm text-gray-400">
+        {/* Row count + page size */}
+        <div className="flex items-center gap-3">
+          <span>
+            {sorted.length === 0
+              ? "No results"
+              : `${(safePage - 1) * pageSize + 1}–${Math.min(
+                  safePage * pageSize,
+                  sorted.length
+                )} of ${sorted.length}`}
+          </span>
+          <label className="flex items-center gap-1.5 text-xs">
+            <span className="text-gray-500">per page</span>
+            <select
+              value={pageSize}
+              onChange={(e) => {
+                setPageSize(Number(e.target.value));
+                setPage(1);
+              }}
+              aria-label="Rows per page"
+              className="bg-white/5 border border-white/10 rounded-lg px-2 py-1 text-gray-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/60"
+            >
+              {PAGE_SIZE_OPTIONS.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {/* Page buttons */}
+        <nav aria-label="Table pagination" className="flex items-center gap-1">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={safePage === 1}
+            aria-label="Previous page"
+            className={cn(
+              "p-1.5 rounded-lg transition-colors",
+              safePage === 1
+                ? "opacity-30 cursor-not-allowed"
+                : "hover:bg-white/10 hover:text-white"
+            )}
+          >
+            <ChevronLeft size={16} />
+          </button>
+
+          {/* Page number pills */}
+          {Array.from({ length: totalPages }, (_, i) => i + 1)
+            .filter(
+              (p) =>
+                p === 1 ||
+                p === totalPages ||
+                Math.abs(p - safePage) <= 1
+            )
+            .reduce<(number | "…")[]>((acc, p, idx, arr) => {
+              if (idx > 0 && (p as number) - (arr[idx - 1] as number) > 1) {
+                acc.push("…");
+              }
+              acc.push(p);
+              return acc;
+            }, [])
+            .map((p, idx) =>
+              p === "…" ? (
+                <span key={`ellipsis-${idx}`} className="px-1 text-gray-600">
+                  …
+                </span>
+              ) : (
+                <button
+                  key={p}
+                  onClick={() => setPage(p as number)}
+                  aria-label={`Page ${p}`}
+                  aria-current={safePage === p ? "page" : undefined}
+                  className={cn(
+                    "min-w-[32px] h-8 px-2 rounded-lg text-xs font-medium transition-colors",
+                    safePage === p
+                      ? "bg-primary-600 text-white"
+                      : "hover:bg-white/10 hover:text-white"
+                  )}
+                >
+                  {p}
+                </button>
+              )
+            )}
+
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={safePage === totalPages}
+            aria-label="Next page"
+            className={cn(
+              "p-1.5 rounded-lg transition-colors",
+              safePage === totalPages
+                ? "opacity-30 cursor-not-allowed"
+                : "hover:bg-white/10 hover:text-white"
+            )}
+          >
+            <ChevronRight size={16} />
+          </button>
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/DepositModal.tsx
+++ b/frontend/src/components/DepositModal.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { cn } from './Shimmer';
 import { X } from 'lucide-react';
+import { FormErrorSummary } from './FormErrorSummary';
 
 interface DepositModalProps {
   isOpen: boolean;
@@ -78,7 +79,7 @@ export function DepositModal({ isOpen, onClose, onDeposit, balance }: DepositMod
               </div>
             </div>
             
-            {error && <p className="text-sm text-rose-500 mt-1">{error}</p>}
+            <FormErrorSummary errors={error ? [{ message: error }] : undefined} />
           </div>
 
           <div className="bg-slate-50 dark:bg-slate-800/50 p-4 rounded-lg space-y-2 text-sm">

--- a/frontend/src/components/FormErrorSummary.tsx
+++ b/frontend/src/components/FormErrorSummary.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+import { cn } from "./Shimmer";
+
+export interface FormError {
+  field?: string;
+  message: string;
+}
+
+interface FormErrorSummaryProps {
+  /** List of errors to display. Renders nothing when empty or undefined. */
+  errors?: FormError[];
+  /** Optional heading. Defaults to "Please fix the following errors:". */
+  heading?: string;
+  className?: string;
+}
+
+/**
+ * Inline error summary for modal and form flows.
+ *
+ * - Rendered above the submit button so it is visible without scrolling.
+ * - Uses `role="alert"` + `aria-live="assertive"` so screen readers announce
+ *   errors immediately when they appear.
+ * - Focuses itself on mount when there are errors so keyboard users land on it.
+ */
+export function FormErrorSummary({
+  errors,
+  heading = "Please fix the following errors:",
+  className,
+}: FormErrorSummaryProps) {
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  const hasErrors = Array.isArray(errors) && errors.length > 0;
+
+  React.useEffect(() => {
+    if (hasErrors && ref.current) {
+      ref.current.focus();
+    }
+  }, [hasErrors]);
+
+  if (!hasErrors) return null;
+
+  return (
+    <div
+      ref={ref}
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      tabIndex={-1}
+      className={cn(
+        "rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 space-y-2",
+        "focus:outline-none",
+        className
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <AlertTriangle
+          size={16}
+          className="text-red-400 shrink-0"
+          aria-hidden="true"
+        />
+        <p className="text-sm font-semibold text-red-300">{heading}</p>
+      </div>
+
+      {errors!.length === 1 && !errors![0].field ? (
+        <p className="text-xs text-red-400 leading-relaxed pl-6">
+          {errors![0].message}
+        </p>
+      ) : (
+        <ul className="pl-6 space-y-1 list-disc list-inside" aria-label="Form errors">
+          {errors!.map((err, i) => (
+            <li key={i} className="text-xs text-red-400 leading-relaxed">
+              {err.field ? (
+                <>
+                  <span className="font-medium text-red-300">{err.field}:</span>{" "}
+                  {err.message}
+                </>
+              ) : (
+                err.message
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Skeletons.tsx
+++ b/frontend/src/components/Skeletons.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import React from "react";
+import { cn } from "./Shimmer";
+
+// ── Base shimmer block ────────────────────────────────────────────────────
+
+function Bone({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-lg bg-white/8",
+        className
+      )}
+      aria-hidden="true"
+    />
+  );
+}
+
+// ── Stats card skeleton (#114) ────────────────────────────────────────────
+
+/**
+ * Matches the layout of a single treasury / governance stats card:
+ * icon slot + label + large value + optional sub-value.
+ */
+export function StatsCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn("card flex items-start gap-4", className)}
+      aria-label="Loading stat"
+      aria-busy="true"
+    >
+      {/* Icon */}
+      <Bone className="h-12 w-12 rounded-xl shrink-0" />
+
+      <div className="flex-1 space-y-2 pt-1">
+        {/* Label */}
+        <Bone className="h-3.5 w-24" />
+        {/* Value */}
+        <Bone className="h-8 w-32" />
+        {/* Sub-value */}
+        <Bone className="h-3 w-20" />
+      </div>
+    </div>
+  );
+}
+
+/** Row of N stats card skeletons. */
+export function StatsGridSkeleton({
+  count = 3,
+  className,
+}: {
+  count?: number;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+        className
+      )}
+      role="status"
+      aria-label="Loading statistics"
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <StatsCardSkeleton key={i} />
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
+// ── List card skeleton ────────────────────────────────────────────────────
+
+/**
+ * Skeleton for a single list item card (proposal card, treasury entry, etc.)
+ * Header row + two detail lines + action button placeholder.
+ */
+export function ListCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn("card space-y-4", className)}
+      aria-label="Loading item"
+      aria-busy="true"
+    >
+      {/* Header row: title + badge */}
+      <div className="flex items-center justify-between gap-4">
+        <Bone className="h-5 w-2/3" />
+        <Bone className="h-5 w-16 rounded-full" />
+      </div>
+
+      {/* Description lines */}
+      <div className="space-y-2">
+        <Bone className="h-3.5 w-full" />
+        <Bone className="h-3.5 w-4/5" />
+      </div>
+
+      {/* Footer: meta + button */}
+      <div className="flex items-center justify-between gap-4 pt-1">
+        <div className="flex gap-3">
+          <Bone className="h-3 w-20" />
+          <Bone className="h-3 w-16" />
+        </div>
+        <Bone className="h-9 w-24 rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+/** Stack of N list card skeletons. */
+export function ListSkeleton({
+  count = 3,
+  className,
+}: {
+  count?: number;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn("space-y-4", className)}
+      role="status"
+      aria-label="Loading list"
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <ListCardSkeleton key={i} />
+      ))}
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
+// ── Table skeleton ────────────────────────────────────────────────────────
+
+interface TableSkeletonProps {
+  /** Number of header columns. */
+  cols?: number;
+  /** Number of body rows. */
+  rows?: number;
+  className?: string;
+}
+
+/**
+ * Skeleton for a sortable data table with header and rows.
+ */
+export function TableSkeleton({
+  cols = 5,
+  rows = 5,
+  className,
+}: TableSkeletonProps) {
+  return (
+    <div
+      className={cn("card overflow-hidden p-0", className)}
+      role="status"
+      aria-label="Loading table"
+      aria-busy="true"
+    >
+      {/* Header */}
+      <div className="flex gap-4 px-6 py-3 border-b border-white/5 bg-white/3">
+        {Array.from({ length: cols }).map((_, i) => (
+          <Bone
+            key={i}
+            className={cn("h-3.5 rounded-md", i === 0 ? "w-1/4" : "flex-1")}
+          />
+        ))}
+      </div>
+
+      {/* Rows */}
+      {Array.from({ length: rows }).map((_, row) => (
+        <div
+          key={row}
+          className="flex gap-4 px-6 py-4 border-b border-white/5 last:border-0"
+        >
+          {Array.from({ length: cols }).map((_, col) => (
+            <Bone
+              key={col}
+              className={cn(
+                "h-4 rounded-md",
+                col === 0 ? "w-1/4" : "flex-1",
+                // Vary widths slightly for a more realistic look
+                col % 2 === 0 ? "opacity-80" : "opacity-60"
+              )}
+            />
+          ))}
+        </div>
+      ))}
+
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import React, { useEffect, useCallback } from "react";
+import { CheckCircle, XCircle, AlertTriangle, Info, X } from "lucide-react";
+import { cn } from "./Shimmer";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type ToastVariant = "success" | "error" | "warning" | "info";
+
+export interface ToastItem {
+  id: string;
+  variant: ToastVariant;
+  title: string;
+  description?: string;
+  /** Auto-dismiss after this many ms. 0 = no auto-dismiss. Default 5000. */
+  duration?: number;
+}
+
+// ── Store (simple module-level singleton) ──────────────────────────────────
+
+type Listener = (toasts: ToastItem[]) => void;
+
+let _toasts: ToastItem[] = [];
+const _listeners: Set<Listener> = new Set();
+
+function notify() {
+  _listeners.forEach((fn) => fn([..._toasts]));
+}
+
+export const toast = {
+  show(item: Omit<ToastItem, "id">): string {
+    const id = `toast-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    _toasts = [..._toasts, { ...item, id }];
+    notify();
+    return id;
+  },
+  success(title: string, description?: string) {
+    return toast.show({ variant: "success", title, description });
+  },
+  error(title: string, description?: string) {
+    return toast.show({ variant: "error", title, description, duration: 8000 });
+  },
+  warning(title: string, description?: string) {
+    return toast.show({ variant: "warning", title, description });
+  },
+  info(title: string, description?: string) {
+    return toast.show({ variant: "info", title, description });
+  },
+  dismiss(id: string) {
+    _toasts = _toasts.filter((t) => t.id !== id);
+    notify();
+  },
+  dismissAll() {
+    _toasts = [];
+    notify();
+  },
+};
+
+// ── Hook ───────────────────────────────────────────────────────────────────
+
+export function useToasts() {
+  const [toasts, setToasts] = React.useState<ToastItem[]>([..._toasts]);
+
+  useEffect(() => {
+    const fn: Listener = (next) => setToasts(next);
+    _listeners.add(fn);
+    return () => {
+      _listeners.delete(fn);
+    };
+  }, []);
+
+  return toasts;
+}
+
+// ── Single toast item ──────────────────────────────────────────────────────
+
+const VARIANT_STYLES: Record<ToastVariant, string> = {
+  success: "border-emerald-500/40 bg-emerald-500/10",
+  error: "border-red-500/40 bg-red-500/10",
+  warning: "border-amber-500/40 bg-amber-500/10",
+  info: "border-primary-500/40 bg-primary-500/10",
+};
+
+const ICON_STYLES: Record<ToastVariant, string> = {
+  success: "text-emerald-400",
+  error: "text-red-400",
+  warning: "text-amber-400",
+  info: "text-primary-400",
+};
+
+const ICONS: Record<ToastVariant, React.ElementType> = {
+  success: CheckCircle,
+  error: XCircle,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+function ToastItemComponent({ item }: { item: ToastItem }) {
+  const Icon = ICONS[item.variant];
+  const duration = item.duration ?? 5000;
+
+  const dismiss = useCallback(() => toast.dismiss(item.id), [item.id]);
+
+  useEffect(() => {
+    if (duration <= 0) return;
+    const timer = setTimeout(dismiss, duration);
+    return () => clearTimeout(timer);
+  }, [duration, dismiss]);
+
+  return (
+    <div
+      role="alert"
+      aria-live={item.variant === "error" ? "assertive" : "polite"}
+      aria-atomic="true"
+      className={cn(
+        "flex items-start gap-3 w-full max-w-sm rounded-xl border px-4 py-3",
+        "backdrop-blur-xl shadow-glass",
+        "animate-in slide-in-from-right-5 fade-in duration-300",
+        VARIANT_STYLES[item.variant]
+      )}
+    >
+      <Icon
+        size={18}
+        className={cn("mt-0.5 shrink-0", ICON_STYLES[item.variant])}
+        aria-hidden="true"
+      />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-white leading-snug">{item.title}</p>
+        {item.description && (
+          <p className="mt-0.5 text-xs text-gray-400 leading-relaxed">{item.description}</p>
+        )}
+      </div>
+      <button
+        onClick={dismiss}
+        className="shrink-0 text-gray-500 hover:text-white transition-colors rounded-lg p-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+        aria-label="Dismiss notification"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}
+
+// ── Container (mount once in layout) ──────────────────────────────────────
+
+export function ToastContainer() {
+  const toasts = useToasts();
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      aria-label="Notifications"
+      className="fixed bottom-4 right-4 z-[9999] flex flex-col-reverse gap-2 w-full max-w-sm pointer-events-none"
+    >
+      {toasts.map((item) => (
+        <div key={item.id} className="pointer-events-auto">
+          <ToastItemComponent item={item} />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #112
Fixes #113
Fixes #114
Fixes #115

## What changed

### #112 — Toast system (`Toast.tsx`)
- Self-contained module with a `toast.success/error/warning/info/dismiss/dismissAll` API — no additional dependencies
- Module-level singleton store; any component can call `toast.error(...)` without prop-drilling
- `ToastContainer` mounts once in `layout.tsx` in the bottom-right corner
- Auto-dismiss after 5s (8s for errors); configurable per call with `duration`
- `role="alert"` + `aria-live="assertive"/"polite"` based on severity; screen readers announce immediately
- `slide-in-from-right-5 fade-in` entry animation using Tailwind `animate-in`
- Each toast dismissible via keyboard-accessible close button

### #113 — Inline form error summary (`FormErrorSummary.tsx`)
- Renders above the submit button so errors are visible without scrolling
- `role="alert"` + `aria-live="assertive"` + `aria-atomic` — announced immediately on appearance
- Programmatically focuses itself on mount so keyboard users land directly on the error list
- Supports a single message or a field-labelled list (e.g., `Amount: must be positive`)
- Integrated into `DepositModal.tsx`, replacing the bare `<p>` error display
- `tabIndex={-1}` with `focus:outline-none` so focus ring doesn't appear visually

### #114 — Skeleton loaders (`Skeletons.tsx`)
- `StatsCardSkeleton` — icon slot + label + value + sub-value shimmer
- `StatsGridSkeleton(count)` — responsive 1/2/3-col grid of stats skeletons
- `ListCardSkeleton` — header badge + description lines + footer meta + button placeholder
- `ListSkeleton(count)` — stacked list skeletons
- `TableSkeleton(cols, rows)` — header row + N data rows with alternating opacity
- All: `role="status"` + `aria-label` + `sr-only "Loading…"` for accessibility; `animate-pulse` shimmer

### #115 — Data table (`DataTable.tsx`)
- Fully generic `DataTable<T>` — typed column definitions with optional custom `render`
- **Sorting**: click any sortable column header to cycle `asc → desc → none`; `aria-sort` on `<th>`
- **Filtering**: debounced search input across configurable `searchKeys`; clears on empty
- **Pagination**: page-size selector (5/10/20/50); smart page-number pills with ellipsis for large sets; previous/next buttons with disabled states
- Keyboard-accessible: search, page-size, all buttons reachable via Tab
- `aria-labelledby` table caption; `aria-current="page"` on active page button; `aria-label` on pagination nav
- Empty state slot (defaults to contextual "No results for…" message)
- Zebra-striped rows; `overflow-x-auto` for mobile responsiveness

## Accessibility
All four components include ARIA roles, live regions, and keyboard support per WCAG 2.1 AA.