### PR TITLE
feat(frontend): reliability improvements — FE-182, FE-183, FE-187, FE…

### DIFF
--- a/frontend/docs/CONTRIBUTOR_CHECKLIST.md
+++ b/frontend/docs/CONTRIBUTOR_CHECKLIST.md
@@ -1,0 +1,62 @@
+# Frontend Contributor Checklist
+
+Use this checklist before opening a pull request against the StellarGuard frontend. Each section maps to a concern that reviewers will check; addressing every item upfront speeds up review.
+
+---
+
+## 1. Code quality
+
+- [ ] No `any` types introduced without a `// eslint-disable` comment explaining why
+- [ ] No raw `console.log` / `console.error` left in production code paths
+- [ ] All new functions and hooks have clear parameter names (no single-letter generics outside of true generic type parameters)
+- [ ] No duplicated logic that should live in `src/lib/`
+
+## 2. Transaction safety
+
+- [ ] Every new transaction submission path goes through `useTxLifecycle.run()` (idempotency guard is then automatic)
+- [ ] No direct calls to `signAndSubmit()` from components — always via a hook
+- [ ] Buttons that trigger transactions are disabled while `state.stage !== "idle"` or while `isSubmitting()` returns true
+- [ ] Optimistic UI updates are rolled back in the `catch` block if the on-chain call fails
+
+## 3. XLM / stroop handling
+
+- [ ] All user-facing amount inputs use `sanitizeXlmInput()` on every keystroke (controlled input)
+- [ ] Conversion from input string to on-chain value uses `parseXlmToStroops()` — never `Number()` or `parseFloat()`
+- [ ] Display formatting uses `formatXlm()` — never manual `/ 10_000_000` arithmetic
+- [ ] Amount fields reject submission when the parsed value is `0n` or negative (unless a negative amount is intentional)
+
+## 4. Error handling
+
+- [ ] All async operations in hooks catch errors and call `classifyError()` before storing in state
+- [ ] No raw `Error.message` strings exposed directly in UI — route through `AppError.message`
+- [ ] Wallet-not-connected, network-mismatch, and user-rejected paths each surface a distinct, actionable message
+
+## 5. Tests
+
+- [ ] New utility functions in `src/lib/` have a corresponding `.test.ts` file
+- [ ] Happy path **and** at least one error path are covered per new function
+- [ ] `npm run test` passes with no failures before pushing
+
+## 6. Dependency hygiene
+
+- [ ] No new `dependencies` added without a brief justification in the PR description
+- [ ] No new `devDependencies` that duplicate an existing tool (check `package.json` first)
+- [ ] `npm run check:deps` exits 0 (no unused or undeclared packages)
+
+## 7. Accessibility & UX
+
+- [ ] Interactive elements (buttons, inputs) have visible focus styles
+- [ ] Disabled buttons include a `title` or `aria-label` explaining why they are disabled
+- [ ] Loading states show a spinner or skeleton — no silent blank areas
+
+## 8. Docs & issue tracking
+
+- [ ] `docs/ISSUES-FRONTEND.md` checkbox marked `[x]` with your GitHub username and UTC timestamp
+- [ ] If a new architectural decision was made, an ADR has been added to `docs/adr/`
+- [ ] `docs/FRONTEND_GUIDE.md` updated if the project structure, setup steps, or key patterns changed
+
+## 9. Final checks
+
+- [ ] Branch is up to date with `main` (rebased or merged)
+- [ ] PR description references the issue number(s) being closed (e.g. `Closes #166`)
+- [ ] No unrelated files changed (check `git diff --stat origin/main`)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "postcss": "^8.4.0",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.4.0",
+        "vite": "^5.4.21",
         "vitest": "^3.2.4"
       }
     },
@@ -80,445 +81,371 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3328,45 +3255,41 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -7513,24 +7436,20 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -7539,23 +7458,17 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
         "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
         "@types/node": {
-          "optional": true
-        },
-        "jiti": {
           "optional": true
         },
         "less": {
@@ -7577,12 +7490,6 @@
           "optional": true
         },
         "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
           "optional": true
         }
       }
@@ -7608,37 +7515,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "check:deps": "node scripts/check-deps.mjs"
   },
   "dependencies": {
     "@stellar/freighter-api": "^2.0.0",
@@ -31,6 +32,7 @@
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.4.0",
+    "vite": "^5.4.21",
     "vitest": "^3.2.4"
   }
 }

--- a/frontend/scripts/check-deps.mjs
+++ b/frontend/scripts/check-deps.mjs
@@ -1,0 +1,113 @@
+/**
+ * Dependency audit script for StellarGuard frontend.
+ *
+ * Scans all source files for import statements and cross-checks them
+ * against the declared dependencies in package.json. Reports:
+ *   - Declared packages that are never imported (candidates for removal)
+ *   - Packages that are imported but not declared (should be rare with TypeScript)
+ *
+ * Usage:
+ *   node scripts/check-deps.mjs
+ */
+
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join, extname } from "path";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const SRC = join(ROOT, "src");
+const PKG = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+
+// Packages that are implicitly used by the framework or config tooling
+// and do not appear as direct `import` statements in src/.
+const IMPLICIT_DEPS = new Set([
+  "next",           // framework itself; used via next.config.js and CLI
+  "react",          // used as JSX runtime, not always an explicit import
+  "react-dom",      // used by Next.js internally
+  "autoprefixer",   // postcss plugin configured in postcss.config.js
+  "postcss",        // build-time config
+  "tailwindcss",    // build-time config in tailwind.config.ts
+  "typescript",     // compile-time; no runtime import
+  "eslint",         // lint-time; no runtime import
+  "eslint-config-next", // lint config
+  "@types/node",    // type-only
+  "@types/react",   // type-only
+  "@types/react-dom", // type-only
+  "vitest",         // test runner CLI; no src import needed
+  "vite",           // build tool used by vitest; no src import needed
+]);
+
+/** Walk src directory and collect all .ts / .tsx files. */
+function collectSourceFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      files.push(...collectSourceFiles(full));
+    } else if ([".ts", ".tsx"].includes(extname(entry))) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/** Extract bare package names from import/require statements. */
+function extractImportedPackages(files) {
+  const packages = new Set();
+  // Matches: from "pkg", require("pkg"), require('pkg')
+  const importRe = /(?:from\s+|require\s*\(\s*)['"](@?[^./'"@\s][^'"]*)['"]/g;
+
+  for (const file of files) {
+    const src = readFileSync(file, "utf8");
+    for (const [, specifier] of src.matchAll(importRe)) {
+      // Normalise: @scope/pkg/sub → @scope/pkg, pkg/sub → pkg
+      const name = specifier.startsWith("@")
+        ? specifier.split("/").slice(0, 2).join("/")
+        : specifier.split("/")[0];
+      packages.add(name);
+    }
+  }
+  return packages;
+}
+
+const declared = new Set([
+  ...Object.keys(PKG.dependencies ?? {}),
+  ...Object.keys(PKG.devDependencies ?? {}),
+]);
+
+const files = collectSourceFiles(SRC);
+const imported = extractImportedPackages(files);
+
+const unused = [...declared].filter(
+  (p) => !imported.has(p) && !IMPLICIT_DEPS.has(p),
+);
+const undeclared = [...imported].filter(
+  (p) => !declared.has(p) && !p.startsWith("@/") && p !== "node",
+);
+
+console.log(`\nStellarGuard frontend — dependency audit`);
+console.log(`Scanned ${files.length} source files\n`);
+
+if (unused.length === 0) {
+  console.log("✓ No unused declared packages found.");
+} else {
+  console.warn(`⚠  Potentially unused packages (${unused.length}):`);
+  unused.forEach((p) => console.warn(`   - ${p}`));
+}
+
+if (undeclared.length === 0) {
+  console.log("✓ No undeclared imports found.");
+} else {
+  console.warn(`⚠  Imported but not declared (${undeclared.length}):`);
+  undeclared.forEach((p) => console.warn(`   - ${p}`));
+}
+
+console.log("\nVersion notes (run `npm outdated` for details):");
+console.log("  next              14.2.0   — latest major: 15.x (breaking changes; upgrade separately)");
+console.log("  @stellar/stellar-sdk ^11.3.0 — latest major: 15.x (upgrade separately after API review)");
+console.log("  @stellar/freighter-api ^2.0.0 — latest major: 6.x (upgrade separately after API review)");
+console.log("  vitest            ^3.2.4   — latest: 4.x (minor breaking changes; upgrade when ready)");
+console.log("");
+
+const exitCode = unused.length > 0 || undeclared.length > 0 ? 1 : 0;
+process.exit(exitCode);

--- a/frontend/src/hooks/useTxLifecycle.ts
+++ b/frontend/src/hooks/useTxLifecycle.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { type AppError, classifyError } from "@/lib/errors";
+import { createSubmitGuard } from "@/lib/submitGuard";
 
 /**
  * Lifecycle stages of a Soroban transaction, in order.
@@ -63,6 +64,9 @@ const IDLE_STATE: TxState = { stage: "idle", error: null, canRetry: false };
 export function useTxLifecycle() {
   const [state, setState] = useState<TxState>(IDLE_STATE);
   const runIdRef = useRef(0);
+  // One guard per lifecycle instance; prevents a second click from
+  // starting a new submission while the current one is still in-flight.
+  const submitGuardRef = useRef(createSubmitGuard());
 
   const reset = useCallback(() => {
     setState(IDLE_STATE);
@@ -79,44 +83,52 @@ export function useTxLifecycle() {
       sign: (built: TBuilt) => Promise<TResult>;
       /** Called with the result after the chain confirms. */
       onSuccess?: (result: TResult) => void;
-    }): Promise<TResult> => {
-      const runId = ++runIdRef.current;
+    }): Promise<TResult | undefined> => {
+      return submitGuardRef.current.run(async () => {
+        const runId = ++runIdRef.current;
 
-      const setStage = (stage: TxStage) => {
-        if (runIdRef.current === runId) {
-          setState({ stage, error: null, canRetry: false });
+        const setStage = (stage: TxStage) => {
+          if (runIdRef.current === runId) {
+            setState({ stage, error: null, canRetry: false });
+          }
+        };
+
+        try {
+          setStage("building");
+          const built = await steps.build();
+
+          setStage("signing");
+          // signing and submitting are sequential but happen inside signAndSubmit;
+          // we advance to "submitting" immediately after the sign call resolves so
+          // the UI shows deterministic progress.
+          setStage("submitting");
+          const result = await steps.sign(built);
+
+          setStage("confirming");
+
+          if (runIdRef.current === runId) {
+            setState({ stage: "success", error: null, canRetry: false });
+            steps.onSuccess?.(result);
+          }
+
+          return result;
+        } catch (err: unknown) {
+          if (runIdRef.current === runId) {
+            const appError = classifyError(err);
+            setState({ stage: "error", error: appError, canRetry: appError.recoverable });
+          }
+          throw err;
         }
-      };
-
-      try {
-        setStage("building");
-        const built = await steps.build();
-
-        setStage("signing");
-        // signing and submitting are sequential but happen inside signAndSubmit;
-        // we advance to "submitting" immediately after the sign call resolves so
-        // the UI shows deterministic progress.
-        setStage("submitting");
-        const result = await steps.sign(built);
-
-        setStage("confirming");
-
-        if (runIdRef.current === runId) {
-          setState({ stage: "success", error: null, canRetry: false });
-          steps.onSuccess?.(result);
-        }
-
-        return result;
-      } catch (err: unknown) {
-        if (runIdRef.current === runId) {
-          const appError = classifyError(err);
-          setState({ stage: "error", error: appError, canRetry: appError.recoverable });
-        }
-        throw err;
-      }
+      });
     },
     [],
   );
 
-  return { state, run, reset };
+  /** True while a transaction is actively being built, signed, or submitted. */
+  const isSubmitting = useCallback(
+    () => submitGuardRef.current.isSubmitting(),
+    [],
+  );
+
+  return { state, run, reset, isSubmitting };
 }

--- a/frontend/src/lib/formatters.test.ts
+++ b/frontend/src/lib/formatters.test.ts
@@ -4,6 +4,8 @@ import {
   formatAddress,
   formatRelativeDate,
   formatXlm,
+  parseXlmToStroops,
+  sanitizeXlmInput,
 } from "@/lib/formatters";
 
 describe("formatXlm", () => {
@@ -31,6 +33,111 @@ describe("formatAddress", () => {
 
   it("returns short addresses unchanged", () => {
     expect(formatAddress("GSHORT123")).toBe("GSHORT123");
+  });
+});
+
+describe("parseXlmToStroops", () => {
+  it("converts a whole XLM string to stroops", () => {
+    expect(parseXlmToStroops("1")).toBe(BigInt(10_000_000));
+  });
+
+  it("converts a fractional XLM string to stroops", () => {
+    expect(parseXlmToStroops("1.5")).toBe(BigInt(15_000_000));
+  });
+
+  it("converts maximum precision (7 decimals)", () => {
+    expect(parseXlmToStroops("1.0000001")).toBe(BigInt(10_000_001));
+  });
+
+  it("converts negative XLM amounts", () => {
+    expect(parseXlmToStroops("-2")).toBe(BigInt(-20_000_000));
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseXlmToStroops("")).toThrow("Invalid XLM amount format");
+  });
+
+  it("throws on a bare dot", () => {
+    expect(() => parseXlmToStroops(".")).toThrow("Invalid XLM amount format");
+  });
+
+  it("throws on scientific notation", () => {
+    expect(() => parseXlmToStroops("1e7")).toThrow("Invalid XLM amount format");
+  });
+
+  it("throws on Infinity", () => {
+    expect(() => parseXlmToStroops("Infinity")).toThrow("Invalid XLM amount format");
+  });
+
+  it("throws on NaN", () => {
+    expect(() => parseXlmToStroops("NaN")).toThrow("Invalid XLM amount format");
+  });
+
+  it("throws when whole-number part exceeds digit limit", () => {
+    expect(() => parseXlmToStroops("1000000000000")).toThrow(
+      "XLM amount exceeds the maximum Stellar supply",
+    );
+  });
+
+  it("throws on more than 7 decimal places", () => {
+    expect(() => parseXlmToStroops("1.00000001")).toThrow("Invalid XLM amount format");
+  });
+});
+
+describe("sanitizeXlmInput", () => {
+  it("passes through a valid decimal string unchanged", () => {
+    expect(sanitizeXlmInput("12.345")).toBe("12.345");
+  });
+
+  it("strips non-numeric characters", () => {
+    expect(sanitizeXlmInput("1a2b.3c")).toBe("12.3");
+  });
+
+  it("collapses multiple dots to the first one", () => {
+    expect(sanitizeXlmInput("1.2.3")).toBe("1.23");
+  });
+
+  it("preserves a single leading minus", () => {
+    expect(sanitizeXlmInput("-5.0")).toBe("-5.0");
+  });
+
+  it("removes extra minus signs", () => {
+    expect(sanitizeXlmInput("--5")).toBe("-5");
+  });
+
+  it("clamps fractional part to 7 digits", () => {
+    expect(sanitizeXlmInput("1.123456789")).toBe("1.1234567");
+  });
+
+  it("clamps whole part to 12 digits", () => {
+    expect(sanitizeXlmInput("9999999999999")).toBe("999999999999");
+  });
+});
+
+describe("formatXlm — hardened inputs", () => {
+  it("throws on Infinity passed as number", () => {
+    expect(() => formatXlm(Infinity)).toThrow("Stroops value must be a finite integer.");
+  });
+
+  it("throws on NaN passed as number", () => {
+    expect(() => formatXlm(NaN)).toThrow("Stroops value must be a finite integer.");
+  });
+
+  it("throws on a non-integer number", () => {
+    expect(() => formatXlm(1.5)).toThrow("Stroops value must be a finite integer.");
+  });
+
+  it("throws on a non-integer string", () => {
+    expect(() => formatXlm("abc")).toThrow("Stroops value must be an integer string.");
+  });
+
+  it("throws on stroops exceeding Stellar max supply", () => {
+    const overMax = (BigInt(100_000_000_001) * BigInt(10_000_000)).toString();
+    expect(() => formatXlm(overMax)).toThrow("out of the valid Stellar range");
+  });
+
+  it("formats zero stroops correctly", () => {
+    expect(formatXlm(0)).toBe("0.00");
   });
 });
 

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -1,5 +1,12 @@
 const STROOPS_PER_XLM = BigInt(10_000_000);
 
+// Stellar's hard-coded maximum supply: 100 billion XLM in stroops.
+const MAX_STROOPS = BigInt(100_000_000_000) * STROOPS_PER_XLM;
+
+// Maximum digits accepted in an XLM whole-number part before conversion,
+// sized to prevent BigInt construction from arbitrarily long user strings.
+const MAX_XLM_WHOLE_DIGITS = 12;
+
 type StroopsInput = bigint | number | string;
 
 export interface XlmFormatOptions {
@@ -30,7 +37,18 @@ function normalizeStroops(value: StroopsInput): bigint {
     throw new Error("Stroops value must be an integer string.");
   }
 
-  return BigInt(normalized);
+  // Reject strings long enough to produce a value that can never be valid
+  // stroops, guarding against intentional or accidental BigInt overflow.
+  if (normalized.replace("-", "").length > MAX_XLM_WHOLE_DIGITS + 7) {
+    throw new Error("Stroops value is out of the valid Stellar range.");
+  }
+
+  const result = BigInt(normalized);
+  if (result > MAX_STROOPS || result < -MAX_STROOPS) {
+    throw new Error("Stroops value is out of the valid Stellar range.");
+  }
+
+  return result;
 }
 
 export function formatXlm(
@@ -89,17 +107,78 @@ export function formatAddress(
 
 export function parseXlmToStroops(value: string): bigint {
   const normalized = value.trim();
+
+  if (
+    normalized === "" ||
+    normalized === "." ||
+    normalized.toLowerCase().includes("e") ||
+    normalized.toLowerCase() === "infinity" ||
+    normalized.toLowerCase() === "-infinity" ||
+    normalized.toLowerCase() === "nan"
+  ) {
+    throw new Error("Invalid XLM amount format. Use up to 7 decimal places.");
+  }
+
   if (!/^-?\d+(?:\.\d{1,7})?$/.test(normalized)) {
     throw new Error("Invalid XLM amount format. Use up to 7 decimal places.");
   }
 
   const [wholePart = "0", fractionPart = ""] = normalized.split(".");
+  const absWhole = wholePart.replace("-", "");
+
+  if (absWhole.length > MAX_XLM_WHOLE_DIGITS) {
+    throw new Error("XLM amount exceeds the maximum Stellar supply.");
+  }
+
   const sign = wholePart.startsWith("-") ? BigInt(-1) : BigInt(1);
-  const whole = BigInt(wholePart.replace("-", ""));
+  const whole = BigInt(absWhole);
   const fraction = fractionPart.padEnd(7, "0").slice(0, 7);
   const stroops = whole * STROOPS_PER_XLM + BigInt(fraction);
 
+  if (stroops > MAX_STROOPS) {
+    throw new Error("XLM amount exceeds the maximum Stellar supply.");
+  }
+
   return stroops * sign;
+}
+
+/**
+ * Sanitise a raw form input string for the XLM amount field.
+ *
+ * - Strips any character that is not a digit, dot, or leading minus.
+ * - Limits the whole-number part to MAX_XLM_WHOLE_DIGITS digits.
+ * - Limits the fractional part to 7 digits (one stroop precision).
+ * - Collapses multiple dots down to one.
+ *
+ * Returns the sanitised string, suitable for controlled input state.
+ */
+export function sanitizeXlmInput(raw: string): string {
+  // Keep only digits, dots, and a single leading minus.
+  let s = raw.replace(/[^\d.-]/g, "");
+
+  // Preserve at most one leading minus.
+  const negative = s.startsWith("-");
+  s = (negative ? "-" : "") + s.replace(/-/g, "");
+
+  // Collapse multiple dots — keep only the first.
+  const firstDot = s.indexOf(".");
+  if (firstDot !== -1) {
+    s = s.slice(0, firstDot + 1) + s.slice(firstDot + 1).replace(/\./g, "");
+  }
+
+  // Clamp whole part length.
+  const dotIndex = s.indexOf(".");
+  if (dotIndex === -1) {
+    const start = negative ? 1 : 0;
+    s = s.slice(0, start + MAX_XLM_WHOLE_DIGITS);
+  } else {
+    const start = negative ? 1 : 0;
+    const whole = s.slice(start, dotIndex).slice(0, MAX_XLM_WHOLE_DIGITS);
+    const frac = s.slice(dotIndex + 1).slice(0, 7);
+    s = (negative ? "-" : "") + whole + "." + frac;
+  }
+
+  return s;
 }
 
 export function formatAbsoluteDate(

--- a/frontend/src/lib/submitGuard.test.ts
+++ b/frontend/src/lib/submitGuard.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSubmitGuard } from "@/lib/submitGuard";
+
+describe("submitGuard", () => {
+  it("runs the function and returns its result", async () => {
+    const guard = createSubmitGuard();
+    const result = await guard.run(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("reports isSubmitting() true while running", async () => {
+    const guard = createSubmitGuard();
+
+    let resolveInner!: () => void;
+    const innerPromise = new Promise<void>((res) => {
+      resolveInner = res;
+    });
+
+    const runPromise = guard.run(async () => {
+      await innerPromise;
+      return "done";
+    });
+
+    expect(guard.isSubmitting()).toBe(true);
+    resolveInner();
+    await runPromise;
+    expect(guard.isSubmitting()).toBe(false);
+  });
+
+  it("drops a concurrent call and returns undefined", async () => {
+    const guard = createSubmitGuard();
+
+    let resolveFirst!: () => void;
+    const firstPromise = new Promise<void>((res) => {
+      resolveFirst = res;
+    });
+
+    const secondFn = vi.fn(async () => "second");
+
+    // First call starts but hasn't resolved yet
+    const first = guard.run(async () => {
+      await firstPromise;
+      return "first";
+    });
+
+    // Second call while first is in-flight should be dropped
+    const second = await guard.run(secondFn);
+
+    expect(second).toBeUndefined();
+    expect(secondFn).not.toHaveBeenCalled();
+
+    resolveFirst();
+    await first;
+  });
+
+  it("allows a second call after the first resolves", async () => {
+    const guard = createSubmitGuard();
+
+    const first = await guard.run(async () => "first");
+    expect(first).toBe("first");
+
+    const second = await guard.run(async () => "second");
+    expect(second).toBe("second");
+  });
+
+  it("clears submitting state even when the function throws", async () => {
+    const guard = createSubmitGuard();
+
+    await expect(
+      guard.run(async () => {
+        throw new Error("tx failed");
+      }),
+    ).rejects.toThrow("tx failed");
+
+    expect(guard.isSubmitting()).toBe(false);
+
+    // Should be able to retry after failure
+    const retry = await guard.run(async () => "retry ok");
+    expect(retry).toBe("retry ok");
+  });
+});

--- a/frontend/src/lib/submitGuard.ts
+++ b/frontend/src/lib/submitGuard.ts
@@ -1,0 +1,47 @@
+/**
+ * Idempotency guard for transaction submissions.
+ *
+ * Wraps an async operation so that concurrent calls issued before the
+ * first one resolves are dropped rather than queued. This is the
+ * correct semantics for one-shot blockchain transactions: a second click
+ * while "Signing…" should be silently ignored, not enqueued.
+ *
+ * Usage:
+ *   const guard = createSubmitGuard();
+ *   await guard.run(() => signAndSubmit(tx));
+ *
+ *   // check from outside:
+ *   if (guard.isSubmitting()) { ... }
+ */
+
+export interface SubmitGuard {
+  /**
+   * Run `fn` if no submission is currently in-flight.
+   * Returns the result of `fn`, or `undefined` if a submission was
+   * already in progress and this call was dropped.
+   */
+  run<T>(fn: () => Promise<T>): Promise<T | undefined>;
+
+  /** True while a submission started by `run()` is still pending. */
+  isSubmitting(): boolean;
+}
+
+export function createSubmitGuard(): SubmitGuard {
+  let submitting = false;
+
+  return {
+    async run<T>(fn: () => Promise<T>): Promise<T | undefined> {
+      if (submitting) return undefined;
+      submitting = true;
+      try {
+        return await fn();
+      } finally {
+        submitting = false;
+      }
+    },
+
+    isSubmitting() {
+      return submitting;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- **FE-182** (`#165`): Hardened XLM/stroop numeric conversions — `parseXlmToStroops` now rejects empty strings, bare dots, scientific notation, `Infinity`, `NaN`, and values above Stellar's 100 billion XLM cap; new `sanitizeXlmInput()` helper for controlled form inputs; `formatXlm`/`normalizeStroops` guard against out-of-range stroop strings
- **FE-183** (`#166`): Added idempotency guard for transaction submissions — new `createSubmitGuard()` utility drops concurrent calls while a submission is in-flight; wired into `useTxLifecycle.run()` so a second button click during signing/submitting is silently ignored rather than queued; `isSubmitting()` exposed for disabling UI elements
- **FE-187** (`#170`): Audited all declared frontend packages — confirmed zero unused packages; added `scripts/check-deps.mjs` (`npm run check:deps`) that scans source imports vs `package.json` and exits non-zero on drift; pinned `vite@^5` to fix test runner compatibility on Node 18
- **FE-196** (`#179`): Created `frontend/docs/CONTRIBUTOR_CHECKLIST.md` — covers code quality, transaction safety, XLM/stroop handling, error handling, tests, dependency hygiene, accessibility/UX, and issue-tracking steps

## Test plan

- [x] `npm run test` — 55 tests, all passing (4 test files: `formatters`, `submitGuard`, `requestGuard`, `contractData`)
- [x] `node scripts/check-deps.mjs` — exits 0, no unused or undeclared packages
- [x] New `submitGuard.test.ts` covers: happy path, `isSubmitting` during run, concurrent call dropped, sequential retry after completion, error recovery (submitting flag cleared on throw)
- [x] New formatter tests cover: `parseXlmToStroops` happy paths + 8 rejection cases; `sanitizeXlmInput` 7 cases; `formatXlm` hardened inputs including Infinity/NaN/out-of-range

Closes #165 
Closes #166 
Closes #170 
Closes #179 
