### PR TITLE
Resolve FE-184/186/188/192 frontend quality upgrades

### DIFF
--- a/frontend/QUALITY.md
+++ b/frontend/QUALITY.md
@@ -1,0 +1,37 @@
+# Frontend Quality Guardrails
+
+This package now includes baseline security, performance, and end-to-end smoke checks.
+
+## Security Headers and CSP
+
+`next.config.js` defines:
+
+- `Content-Security-Policy`
+- `X-Content-Type-Options`
+- `X-Frame-Options`
+- `Referrer-Policy`
+- `Permissions-Policy`
+- `Cross-Origin-Opener-Policy`
+- `Cross-Origin-Resource-Policy`
+
+For local development, CSP keeps `unsafe-eval` enabled to support Next.js dev tooling. Production builds remove it.
+
+## Bundle Analysis
+
+Generate bundle reports:
+
+```bash
+npm run analyze
+```
+
+This uses `@next/bundle-analyzer` and helps identify large client bundles for further splitting.
+
+## E2E Smoke Test
+
+Run the mocked treasury happy-path smoke test:
+
+```bash
+npm run test:e2e
+```
+
+The Playwright config starts the app with `NEXT_PUBLIC_USE_MOCK_TREASURY=1` so the test is deterministic and does not require live Soroban/Freighter integration.

--- a/frontend/e2e/treasury.smoke.spec.ts
+++ b/frontend/e2e/treasury.smoke.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("treasury happy-path smoke", () => {
+  test("loads treasury dashboard with mocked data", async ({ page }) => {
+    await page.goto("/treasury");
+
+    await expect(
+      page.getByRole("heading", { name: "Treasury" }),
+    ).toBeVisible();
+    await expect(page.getByText("Pending Transactions")).toBeVisible();
+    await expect(page.getByText("Execution History")).toBeVisible();
+
+    await expect(
+      page.getByText("Validator infrastructure costs"),
+    ).toBeVisible();
+    await expect(page.getByText("Quarterly community grant")).toBeVisible();
+    await expect(page.getByText(/matching transaction/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Refresh" })).toBeVisible();
+  });
+});

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,9 +1,50 @@
+const withBundleAnalyzer = require("@next/bundle-analyzer")({
+  enabled: process.env.ANALYZE === "true",
+});
+
+const isDev = process.env.NODE_ENV !== "production";
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline' ${isDev ? "'unsafe-eval'" : ""}`.trim(),
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https: wss:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+].join("; ");
+
+const securityHeaders = [
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value:
+      "camera=(), microphone=(), geolocation=(), browsing-topics=(), interest-cohort=()",
+  },
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
   images: {
     formats: ["image/avif", "image/webp"],
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
   },
   // Stellar SDK requires these for browser compatibility
   webpack: (config) => {
@@ -17,4 +58,4 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+module.exports = withBundleAnalyzer(nextConfig);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,8 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^14.2.0",
+        "@playwright/test": "^1.53.2",
         "@types/node": "^20.0.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
@@ -43,6 +45,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -737,6 +749,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-14.2.35.tgz",
+      "integrity": "sha512-br772Uozk44eJq3a0Z+sTyNII+29d7ue1a0s4xd+9MlUQl3HhKo/wLqxZPFngMbwr6YnAWh/uKoVEpEOV35Fzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.0.tgz",
@@ -1005,6 +1027,30 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
@@ -1479,6 +1525,7 @@
       "integrity": "sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1496,6 +1543,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2055,6 +2103,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2070,6 +2119,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -2605,6 +2667,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2929,7 +2992,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2991,6 +3055,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3124,6 +3195,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3399,6 +3477,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3567,6 +3646,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4339,6 +4419,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -4428,6 +4524,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -4821,6 +4924,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5021,6 +5134,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5314,6 +5428,16 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5633,6 +5757,16 @@
         "wrappy": "1"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5834,6 +5968,53 @@
         "node": ">= 6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5863,6 +6044,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6079,6 +6261,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6091,6 +6274,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6620,6 +6804,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/slash": {
@@ -7152,6 +7351,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7221,6 +7421,16 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
@@ -7389,6 +7599,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7518,6 +7729,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7634,6 +7846,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7725,6 +7938,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/which": {
@@ -7965,6 +8216,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "analyze": "ANALYZE=true next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@stellar/freighter-api": "^2.0.0",
@@ -22,6 +24,8 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^14.2.0",
+    "@playwright/test": "^1.53.2",
     "@types/node": "^20.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "list",
+  use: {
+    baseURL: "http://127.0.0.1:3005",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "NEXT_DISABLE_VERSION_CHECK=1 CI=1 npm run dev -- -p 3005",
+    url: "http://127.0.0.1:3005",
+    reuseExistingServer: !process.env.CI,
+    cwd: __dirname,
+    env: {
+      NEXT_PUBLIC_USE_MOCK_TREASURY: "1",
+      NEXT_DISABLE_VERSION_CHECK: "1",
+      CI: "1",
+      NEXT_PUBLIC_TREASURY_CONTRACT_ID: "mock-treasury-contract",
+      NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID: "mock-governance-contract",
+      NEXT_PUBLIC_VAULT_CONTRACT_ID: "mock-vault-contract",
+      NEXT_PUBLIC_ACL_CONTRACT_ID: "mock-acl-contract",
+      NEXT_PUBLIC_SOROBAN_SIMULATION_ACCOUNT:
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/frontend/src/app/governance/page.tsx
+++ b/frontend/src/app/governance/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ProposalCard } from "@/components/ProposalCard";
-import { CreateProposalModal } from "@/components/CreateProposalModal";
+import dynamic from "next/dynamic";
 import { useGovernance } from "@/hooks/useGovernance";
 import type {
   GovernanceProposal,
@@ -29,6 +28,15 @@ const ACTION_FILTERS: Array<"All" | GovernanceProposalAction> = [
 ];
 
 type SortKey = "newest" | "ending-soon" | "most-votes";
+
+const ProposalCard = dynamic(() =>
+  import("@/components/ProposalCard").then((module) => module.ProposalCard),
+);
+const CreateProposalModal = dynamic(() =>
+  import("@/components/CreateProposalModal").then(
+    (module) => module.CreateProposalModal,
+  ),
+);
 
 const SORT_OPTIONS: Array<{ value: SortKey; label: string }> = [
   { value: "newest", label: "Newest" },

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { FreighterProvider } from "@/context/FreighterProvider";
 import { WalletConnect } from "@/components/WalletConnect";
 import { DiagnosticsPanel } from "@/components/DiagnosticsPanel";
 import { ToastContainer } from "@/components/Toast";
+import { NetworkMismatchBanner } from "@/components/NetworkMismatchBanner";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -93,6 +94,7 @@ export default function RootLayout({
               </div>
             </div>
           </nav>
+          <NetworkMismatchBanner />
           
           <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             {children}

--- a/frontend/src/app/template.tsx
+++ b/frontend/src/app/template.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { motion } from "framer-motion";
 
 const variants = {

--- a/frontend/src/app/treasury/page.tsx
+++ b/frontend/src/app/treasury/page.tsx
@@ -1,16 +1,26 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import dynamic from "next/dynamic";
 import { useTreasury } from "@/hooks/useTreasury";
 import { useFreighter } from "@/hooks/useFreighter";
 import { formatAbsoluteDate, formatAddress, formatXlm } from "@/lib/formatters";
 import { ERROR_CODE_LABELS } from "@/lib/errors";
-import { TreasuryCard } from "@/components/TreasuryCard";
 import { WalletConnect } from "@/components/WalletConnect";
-import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import { CopyButton } from "@/components/CopyButton";
-import { WithdrawalModal } from "@/components/WithdrawalModal";
 import type { TreasuryTransaction } from "@/lib/contractData";
+
+const TreasuryCard = dynamic(() =>
+  import("@/components/TreasuryCard").then((module) => module.TreasuryCard),
+);
+const WithdrawalModal = dynamic(() =>
+  import("@/components/WithdrawalModal").then((module) => module.WithdrawalModal),
+);
+const ConfirmationDialog = dynamic(() =>
+  import("@/components/ConfirmationDialog").then(
+    (module) => module.ConfirmationDialog,
+  ),
+);
 
 export default function TreasuryPage() {
   const { address } = useFreighter();
@@ -37,6 +47,8 @@ export default function TreasuryPage() {
   const [statusFilter, setStatusFilter] = useState<"pending" | "ready" | "executed">(
     "pending",
   );
+  const threshold = config?.threshold ?? 0;
+  const signerCount = config?.signerCount ?? 0;
 
   const pendingTxs = useMemo(
     () => transactions.filter((transaction) => !transaction.executed),
@@ -74,9 +86,6 @@ export default function TreasuryPage() {
     () => filteredTransactions.filter((transaction) => transaction.executed),
     [filteredTransactions],
   );
-
-  const threshold = config?.threshold ?? 0;
-  const signerCount = config?.signerCount ?? 0;
 
   const handleApprove = async (txId: number) => {
     await approve(txId);

--- a/frontend/src/components/NetworkMismatchBanner.tsx
+++ b/frontend/src/components/NetworkMismatchBanner.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useFreighter } from "@/hooks/useFreighter";
+import {
+  ACTIVE_NETWORK,
+  getWalletNetworkLabel,
+  isWalletNetworkMismatch,
+} from "@/lib/network";
+
+export function NetworkMismatchBanner() {
+  const { network, isConnected } = useFreighter();
+  const mismatch = isWalletNetworkMismatch(network);
+
+  if (!isConnected || !mismatch) {
+    return null;
+  }
+
+  return (
+    <div className="border-b border-amber-500/30 bg-amber-900/20">
+      <div className="mx-auto max-w-7xl px-4 py-2 text-sm text-amber-200 sm:px-6 lg:px-8">
+        Wallet network mismatch: Freighter is on{" "}
+        <span className="font-semibold">{getWalletNetworkLabel(network)}</span>, but
+        StellarGuard is configured for{" "}
+        <span className="font-semibold">{ACTIVE_NETWORK.name}</span>. Switch your
+        wallet network to continue.
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -21,10 +21,15 @@ import {
 import { classifyError, type AppError } from "@/lib/errors";
 import { createLatestRequestGuard, isAbortError } from "@/lib/requestGuard";
 import { isWalletNetworkMismatch } from "@/lib/network";
+import {
+  MOCK_TREASURY_CONFIG,
+  MOCK_TREASURY_TRANSACTIONS,
+} from "@/lib/treasuryMocks";
 import { useFreighter } from "./useFreighter";
 
 const REFRESH_INTERVAL = 30_000;
 const MAX_VISIBLE_TRANSACTIONS = 20;
+const IS_TREASURY_MOCK_MODE = process.env.NEXT_PUBLIC_USE_MOCK_TREASURY === "1";
 
 type TxAction = "approve" | "execute";
 
@@ -41,6 +46,7 @@ export function useTreasury() {
   const [isProposing, setIsProposing] = useState(false);
 
   const requestGuardRef = useRef(createLatestRequestGuard());
+  const txCounterRef = useRef(MOCK_TREASURY_CONFIG.txCount);
 
   const isNetworkMismatch = useMemo(
     () => isWalletNetworkMismatch(network),
@@ -149,6 +155,20 @@ export function useTreasury() {
   );
 
   const refresh = useCallback(async () => {
+    if (IS_TREASURY_MOCK_MODE) {
+      setIsLoading(false);
+      setError(null);
+      setConfig({
+        ...MOCK_TREASURY_CONFIG,
+        txCount: txCounterRef.current,
+      });
+      setBalance(MOCK_TREASURY_CONFIG.balance);
+      setTransactions((current) =>
+        current.length > 0 ? current : MOCK_TREASURY_TRANSACTIONS,
+      );
+      return;
+    }
+
     const request = requestGuardRef.current.begin();
 
     if (requestGuardRef.current.isCurrent(request.id)) {
@@ -213,6 +233,34 @@ export function useTreasury() {
 
   const proposeWithdrawal = useCallback(
     async (to: string, amount: bigint | number, memo: string): Promise<void> => {
+      if (IS_TREASURY_MOCK_MODE) {
+        const amountBigInt = typeof amount === "bigint" ? amount : BigInt(amount);
+        const nextId = txCounterRef.current + 1;
+        txCounterRef.current = nextId;
+        setTransactions((current) => [
+          {
+            id: nextId,
+            to,
+            amount: amountBigInt,
+            memo,
+            approvals: address ? [address] : [],
+            executed: false,
+            createdAt: Math.floor(Date.now() / 1000),
+            proposer: address ?? "",
+          },
+          ...current,
+        ]);
+        setConfig((current) =>
+          current
+            ? {
+                ...current,
+                txCount: nextId,
+              }
+            : current,
+        );
+        return;
+      }
+
       assertWalletReady();
       const walletAddress = address as string;
       setError(null);
@@ -241,6 +289,27 @@ export function useTreasury() {
 
   const approve = useCallback(
     async (txId: number): Promise<void> => {
+      if (IS_TREASURY_MOCK_MODE) {
+        if (!address) {
+          throw new Error("Wallet not connected");
+        }
+        setTransactions((current) =>
+          current.map((transaction) => {
+            if (transaction.id !== txId || transaction.executed) {
+              return transaction;
+            }
+            if (transaction.approvals.includes(address)) {
+              return transaction;
+            }
+            return {
+              ...transaction,
+              approvals: [...transaction.approvals, address],
+            };
+          }),
+        );
+        return;
+      }
+
       assertWalletReady();
       const walletAddress = address as string;
       setError(null);
@@ -307,6 +376,20 @@ export function useTreasury() {
 
   const execute = useCallback(
     async (txId: number): Promise<void> => {
+      if (IS_TREASURY_MOCK_MODE) {
+        setTransactions((current) =>
+          current.map((transaction) =>
+            transaction.id === txId
+              ? {
+                  ...transaction,
+                  executed: true,
+                }
+              : transaction,
+          ),
+        );
+        return;
+      }
+
       assertWalletReady();
       const walletAddress = address as string;
       setError(null);

--- a/frontend/src/lib/network.ts
+++ b/frontend/src/lib/network.ts
@@ -80,7 +80,7 @@ export async function fundAccount(address: string): Promise<boolean> {
   }
 }
 
-function normalizeWalletNetwork(
+export function normalizeWalletNetwork(
   value: string,
 ): "testnet" | "futurenet" | "mainnet" | null {
   const normalized = value.trim().toLowerCase();
@@ -108,6 +108,19 @@ function normalizeWalletNetwork(
   }
 
   return null;
+}
+
+export function getWalletNetworkLabel(walletNetwork: string | null): string {
+  if (!walletNetwork) {
+    return "unknown";
+  }
+
+  const normalized = normalizeWalletNetwork(walletNetwork);
+  if (normalized) {
+    return NETWORKS[normalized].name;
+  }
+
+  return walletNetwork;
 }
 
 export function isWalletNetworkMismatch(walletNetwork: string | null): boolean {

--- a/frontend/src/lib/treasuryMocks.ts
+++ b/frontend/src/lib/treasuryMocks.ts
@@ -1,0 +1,35 @@
+import type { TreasuryConfig, TreasuryTransaction } from "@/lib/contractData";
+
+export const MOCK_TREASURY_ADDRESS =
+  "GABCD1234EFGH5678IJKL9012MNOP3456QRST7890UVWX1234YZAB";
+
+export const MOCK_TREASURY_CONFIG: TreasuryConfig = {
+  admin: MOCK_TREASURY_ADDRESS,
+  threshold: 2,
+  signerCount: 3,
+  balance: BigInt("1250000000"),
+  txCount: 2,
+};
+
+export const MOCK_TREASURY_TRANSACTIONS: TreasuryTransaction[] = [
+  {
+    id: 2,
+    to: "GCDEST000000000000000000000000000000000000000000000000000000",
+    amount: BigInt("50000000"),
+    memo: "Validator infrastructure costs",
+    approvals: [MOCK_TREASURY_ADDRESS],
+    executed: false,
+    createdAt: 1_714_003_200,
+    proposer: MOCK_TREASURY_ADDRESS,
+  },
+  {
+    id: 1,
+    to: "GCRECIPIENT00000000000000000000000000000000000000000000000000",
+    amount: BigInt("100000000"),
+    memo: "Quarterly community grant",
+    approvals: [MOCK_TREASURY_ADDRESS, "GCSIGNEREXTRA0000000000000000000000000000000000000000000000"],
+    executed: true,
+    createdAt: 1_713_916_800,
+    proposer: MOCK_TREASURY_ADDRESS,
+  },
+];


### PR DESCRIPTION
## Summary
- add a global wallet/network mismatch warning banner and network-label helpers so mismatch states are visible across pages
- harden frontend response headers with CSP + common security headers, and add bundle analysis support via `npm run analyze`
- improve client bundle splitting with dynamic imports on treasury/governance heavy UI sections and document quality workflows
- add mocked Playwright treasury smoke coverage with deterministic mock mode for `useTreasury`

## Verification
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`
- `npm --prefix frontend run test:e2e` *(requires Playwright Chromium install in host environment; browser download was blocked in this sandbox)*

Closes #167
Closes #169
Closes #171
Closes #175
