### PR TITLE
feat: wire vote buttons, add tx timestamps, auto-refresh pause, withdrawal validation

### DIFF
--- a/frontend/src/app/treasury/page.tsx
+++ b/frontend/src/app/treasury/page.tsx
@@ -30,18 +30,25 @@ export default function TreasuryPage() {
     clearError,
   } = useTreasury();
 
-  const [selectedTx, setSelectedTx] = useState<TreasuryTransaction | null>(null);
-  const [confirmExecuteTxId, setConfirmExecuteTxId] = useState<number | null>(null);
+  const [selectedTx, setSelectedTx] = useState<TreasuryTransaction | null>(
+    null,
+  );
+  const [confirmExecuteTxId, setConfirmExecuteTxId] = useState<number | null>(
+    null,
+  );
   const [showWithdrawalModal, setShowWithdrawalModal] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<"pending" | "ready" | "executed">(
-    "pending",
-  );
+  const [statusFilter, setStatusFilter] = useState<
+    "pending" | "ready" | "executed"
+  >("pending");
 
   const pendingTxs = useMemo(
     () => transactions.filter((transaction) => !transaction.executed),
     [transactions],
   );
+
+  const threshold = config?.threshold ?? 0;
+  const signerCount = config?.signerCount ?? 0;
 
   const filteredTransactions = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -50,9 +57,11 @@ export default function TreasuryPage() {
       if (statusFilter === "executed") {
         statusMatches = transaction.executed;
       } else if (statusFilter === "ready") {
-        statusMatches = !transaction.executed && transaction.approvals.length >= threshold;
+        statusMatches =
+          !transaction.executed && transaction.approvals.length >= threshold;
       } else if (statusFilter === "pending") {
-        statusMatches = !transaction.executed && transaction.approvals.length < threshold;
+        statusMatches =
+          !transaction.executed && transaction.approvals.length < threshold;
       }
       if (!statusMatches) {
         return false;
@@ -75,8 +84,7 @@ export default function TreasuryPage() {
     [filteredTransactions],
   );
 
-  const threshold = config?.threshold ?? 0;
-  const signerCount = config?.signerCount ?? 0;
+  // threshold and signerCount are derived above from config
 
   const handleApprove = async (txId: number) => {
     await approve(txId);
@@ -105,7 +113,14 @@ export default function TreasuryPage() {
 
   const exportHistoryCsv = () => {
     const rows = [
-      ["id", "destination", "amount_xlm", "status", "approvals", "created_at_unix"],
+      [
+        "id",
+        "destination",
+        "amount_xlm",
+        "status",
+        "approvals",
+        "created_at_unix",
+      ],
       ...filteredHistoryTxs.map((transaction) => [
         String(transaction.id),
         transaction.to,
@@ -117,9 +132,7 @@ export default function TreasuryPage() {
     ];
     const csv = rows
       .map((row) =>
-        row
-          .map((cell) => `"${cell.replaceAll('"', '""')}"`)
-          .join(","),
+        row.map((cell) => `"${cell.replaceAll('"', '""')}"`).join(","),
       )
       .join("\n");
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
@@ -191,7 +204,9 @@ export default function TreasuryPage() {
 
       {isNetworkMismatch && (
         <div className="card border-red-500/40 bg-red-950/20">
-          <h2 className="text-sm font-semibold text-red-300">Network mismatch</h2>
+          <h2 className="text-sm font-semibold text-red-300">
+            Network mismatch
+          </h2>
           <p className="text-sm text-red-200 mt-1">
             Your wallet is on a different network than the configured contracts.
             Switch networks in Freighter, then retry.
@@ -201,7 +216,9 @@ export default function TreasuryPage() {
 
       {!address && (
         <div className="card border-yellow-500/40 bg-yellow-950/20">
-          <h2 className="text-sm font-semibold text-yellow-300">Wallet disconnected</h2>
+          <h2 className="text-sm font-semibold text-yellow-300">
+            Wallet disconnected
+          </h2>
           <p className="text-sm text-yellow-200 mt-1">
             Connect your wallet to approve or execute treasury transactions.
           </p>
@@ -235,7 +252,9 @@ export default function TreasuryPage() {
           <div>
             <p className="text-sm text-gray-400">Treasury Balance</p>
             <p className="text-3xl font-bold text-white mt-1">
-              {isLoading && balance === BigInt(0) ? "Loading..." : `${formatXlm(balance)} XLM`}
+              {isLoading && balance === BigInt(0)
+                ? "Loading..."
+                : `${formatXlm(balance)} XLM`}
             </p>
           </div>
           <div>
@@ -248,10 +267,15 @@ export default function TreasuryPage() {
             <p className="text-sm text-gray-400">Admin</p>
             <div className="flex items-center gap-2 mt-1">
               <p className="text-sm text-gray-200 font-mono">
-                {config?.admin ? formatAddress(config.admin, { startChars: 6, endChars: 4 }) : "-"}
+                {config?.admin
+                  ? formatAddress(config.admin, { startChars: 6, endChars: 4 })
+                  : "-"}
               </p>
               {config?.admin && (
-                <CopyButton value={config.admin} label="treasury admin address" />
+                <CopyButton
+                  value={config.admin}
+                  label="treasury admin address"
+                />
               )}
             </div>
           </div>
@@ -259,12 +283,18 @@ export default function TreasuryPage() {
       </div>
 
       <div>
-        <h2 className="text-xl font-semibold text-white mb-4">Pending Transactions</h2>
+        <h2 className="text-xl font-semibold text-white mb-4">
+          Pending Transactions
+        </h2>
         <div className="space-y-4">
-          {pendingTxs.filter((transaction) => filteredTransactions.some((item) => item.id === transaction.id)).length === 0 ? (
+          {pendingTxs.filter((transaction) =>
+            filteredTransactions.some((item) => item.id === transaction.id),
+          ).length === 0 ? (
             <div className="card">
               <p className="text-gray-500 text-center py-8">
-                {isLoading ? "Loading transactions..." : "No pending transactions."}
+                {isLoading
+                  ? "Loading transactions..."
+                  : "No pending transactions."}
               </p>
             </div>
           ) : (
@@ -308,7 +338,9 @@ export default function TreasuryPage() {
       </div>
 
       <div>
-        <h2 className="text-xl font-semibold text-white mb-4">Execution History</h2>
+        <h2 className="text-xl font-semibold text-white mb-4">
+          Execution History
+        </h2>
         <div className="card overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
@@ -316,14 +348,17 @@ export default function TreasuryPage() {
                 <th className="text-left py-3 px-4">ID</th>
                 <th className="text-left py-3 px-4">Destination</th>
                 <th className="text-left py-3 px-4">Amount</th>
-                <th className="text-left py-3 px-4">Time</th>
+                <th className="text-left py-3 px-4">Proposed</th>
+                <th className="text-left py-3 px-4">Confirmed</th>
               </tr>
             </thead>
             <tbody>
               {filteredHistoryTxs.length === 0 ? (
                 <tr>
-                  <td colSpan={4} className="text-center text-gray-500 py-8">
-                    {isLoading ? "Loading execution history..." : "No executed transactions for the current filters."}
+                  <td colSpan={5} className="text-center text-gray-500 py-8">
+                    {isLoading
+                      ? "Loading execution history..."
+                      : "No executed transactions for the current filters."}
                   </td>
                 </tr>
               ) : (
@@ -343,10 +378,24 @@ export default function TreasuryPage() {
                       </div>
                     </td>
                     <td className="py-3 px-4 text-gray-300 font-mono">
-                      {formatAddress(transaction.to, { startChars: 6, endChars: 4 })}
+                      {formatAddress(transaction.to, {
+                        startChars: 6,
+                        endChars: 4,
+                      })}
                     </td>
-                    <td className="py-3 px-4 text-gray-300">{formatXlm(transaction.amount)} XLM</td>
-                    <td className="py-3 px-4 text-gray-400">{formatAbsoluteDate(transaction.createdAt * 1000)}</td>
+                    <td className="py-3 px-4 text-gray-300">
+                      {formatXlm(transaction.amount)} XLM
+                    </td>
+                    <td className="py-3 px-4 text-gray-400">
+                      {formatAbsoluteDate(transaction.createdAt * 1000)}
+                    </td>
+                    <td className="py-3 px-4 text-gray-400">
+                      {transaction.executedAt != null ? (
+                        formatAbsoluteDate(transaction.executedAt * 1000)
+                      ) : (
+                        <span className="text-gray-600 italic">—</span>
+                      )}
+                    </td>
                   </tr>
                 ))
               )}
@@ -363,7 +412,9 @@ export default function TreasuryPage() {
           />
           <div className="fixed right-0 top-0 h-full w-full max-w-md bg-background border-l border-stellar-border z-50 p-6 shadow-2xl overflow-y-auto transform transition-transform">
             <div className="flex justify-between items-center mb-6">
-              <h2 className="text-xl font-bold text-white">Transaction Details</h2>
+              <h2 className="text-xl font-bold text-white">
+                Transaction Details
+              </h2>
               <button
                 onClick={() => setSelectedTx(null)}
                 className="text-gray-400 hover:text-white"
@@ -387,7 +438,9 @@ export default function TreasuryPage() {
               <div>
                 <p className="text-xs text-gray-500 uppercase">Destination</p>
                 <div className="mt-1 flex items-center gap-2">
-                  <p className="text-sm text-gray-200 font-mono break-all">{selectedTx.to}</p>
+                  <p className="text-sm text-gray-200 font-mono break-all">
+                    {selectedTx.to}
+                  </p>
                   <CopyButton
                     value={selectedTx.to}
                     label={`transaction ${selectedTx.id} destination address`}
@@ -397,26 +450,35 @@ export default function TreasuryPage() {
 
               <div>
                 <p className="text-xs text-gray-500 uppercase">Amount</p>
-                <p className="text-sm text-gray-200 mt-1">{formatXlm(selectedTx.amount)} XLM</p>
+                <p className="text-sm text-gray-200 mt-1">
+                  {formatXlm(selectedTx.amount)} XLM
+                </p>
               </div>
 
               <div>
                 <p className="text-xs text-gray-500 uppercase">Memo</p>
-                <p className="text-sm text-gray-200 mt-1">{selectedTx.memo || "-"}</p>
+                <p className="text-sm text-gray-200 mt-1">
+                  {selectedTx.memo || "-"}
+                </p>
               </div>
 
               <div>
                 <p className="text-xs text-gray-500 uppercase">Approvals</p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {selectedTx.approvals.length === 0 ? (
-                    <span className="text-xs text-gray-500">No approvals yet</span>
+                    <span className="text-xs text-gray-500">
+                      No approvals yet
+                    </span>
                   ) : (
                     selectedTx.approvals.map((approver) => (
                       <span
                         key={`${selectedTx.id}-${approver}`}
                         className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-gray-300"
                       >
-                        {formatAddress(approver, { startChars: 4, endChars: 4 })}
+                        {formatAddress(approver, {
+                          startChars: 4,
+                          endChars: 4,
+                        })}
                       </span>
                     ))
                   )}
@@ -431,16 +493,30 @@ export default function TreasuryPage() {
                   </p>
                 </div>
                 <div className="flex-1">
-                  <p className="text-xs text-gray-500 uppercase">Created</p>
+                  <p className="text-xs text-gray-500 uppercase">Proposed</p>
                   <p className="text-sm text-gray-200 mt-1">
                     {formatAbsoluteDate(selectedTx.createdAt * 1000)}
                   </p>
                 </div>
               </div>
+
+              {selectedTx.executedAt != null && (
+                <div>
+                  <p className="text-xs text-gray-500 uppercase">
+                    Confirmed on-chain
+                  </p>
+                  <p className="text-sm text-green-400 mt-1 font-medium">
+                    {formatAbsoluteDate(selectedTx.executedAt * 1000)}
+                  </p>
+                </div>
+              )}
             </div>
 
             <div className="mt-8 pt-6 border-t border-stellar-border">
-              <button className="w-full btn-secondary py-3" onClick={() => setSelectedTx(null)}>
+              <button
+                className="w-full btn-secondary py-3"
+                onClick={() => setSelectedTx(null)}
+              >
                 Close
               </button>
             </div>

--- a/frontend/src/components/VoteButton.tsx
+++ b/frontend/src/components/VoteButton.tsx
@@ -21,9 +21,14 @@ export const VoteButton: React.FC<VoteButtonProps> = ({
   onVoteSuccess,
 }) => {
   const { isConnected } = useFreighter();
-  const { vote, isLoading } = useGovernance();
+  const { vote, pendingVotes } = useGovernance();
 
-  const isDisabled = hasVoted || votingClosed || !isConnected || isLoading || isPending;
+  // Use per-proposal pending state from the map rather than the global isLoading
+  // flag so that voting on one proposal doesn't disable buttons on others.
+  const isThisVotePending = isPending || pendingVotes.has(proposalId);
+
+  const isDisabled =
+    hasVoted || votingClosed || !isConnected || isThisVotePending;
 
   const handleVote = async () => {
     if (isDisabled) {
@@ -32,7 +37,9 @@ export const VoteButton: React.FC<VoteButtonProps> = ({
 
     try {
       await vote(proposalId, voteFor);
-      toast.success(`Vote submitted ${voteFor ? "for" : "against"} proposal #${proposalId}`);
+      toast.success(
+        `Vote submitted ${voteFor ? "for" : "against"} proposal #${proposalId}`,
+      );
       await onVoteSuccess?.();
     } catch (error: unknown) {
       toast.error(
@@ -48,7 +55,7 @@ export const VoteButton: React.FC<VoteButtonProps> = ({
       ? "Voting is closed"
       : !isConnected
         ? "Connect your wallet to vote"
-        : isPending
+        : isThisVotePending
           ? "Waiting for vote confirmation"
           : "";
 
@@ -60,7 +67,7 @@ export const VoteButton: React.FC<VoteButtonProps> = ({
       title={title}
       type="button"
     >
-      {isLoading || isPending
+      {isThisVotePending
         ? "Submitting..."
         : voteFor
           ? "Vote For"

--- a/frontend/src/components/WithdrawalModal.tsx
+++ b/frontend/src/components/WithdrawalModal.tsx
@@ -3,8 +3,18 @@
 import React, { useState } from "react";
 import { X } from "lucide-react";
 import { parseXlmToStroops } from "@/lib/formatters";
-import { isValidStellarAddress } from "@/lib/stellarAddress";
+import {
+  getStellarAddressType,
+  isValidStellarAddress,
+} from "@/lib/stellarAddress";
 import { cn } from "./Shimmer";
+
+/** Stellar text memo max is 28 bytes (UTF-8). */
+const MEMO_MAX_BYTES = 28;
+
+function memoByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
 
 interface WithdrawalModalProps {
   isOpen: boolean;
@@ -14,122 +24,217 @@ interface WithdrawalModalProps {
   isProposing: boolean;
 }
 
-export function WithdrawalModal({ isOpen, onClose, onPropose, balance, isProposing }: WithdrawalModalProps) {
+export function WithdrawalModal({
+  isOpen,
+  onClose,
+  onPropose,
+  balance,
+  isProposing,
+}: WithdrawalModalProps) {
   const [to, setTo] = useState("");
   const [amount, setAmount] = useState("");
   const [memo, setMemo] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   if (!isOpen) return null;
 
   const balanceXlm = Number(balance) / 10 ** 7;
   const amountNum = Number(amount);
   const normalizedRecipient = to.trim();
-  const isValidAddress = isValidStellarAddress(normalizedRecipient);
-  const isValidAmount = !isNaN(amountNum) && amountNum > 0 && amountNum <= balanceXlm;
-  const isValid = isValidAddress && isValidAmount && memo.trim().length > 0;
+  const addressType = getStellarAddressType(normalizedRecipient);
+  const isValidAddress = addressType !== null;
+  const isValidAmount =
+    amount !== "" &&
+    !isNaN(amountNum) &&
+    amountNum > 0 &&
+    amountNum <= balanceXlm;
+  const memoBytes = memoByteLength(memo);
+  const isMemoValid = memo.trim().length > 0 && memoBytes <= MEMO_MAX_BYTES;
+  const isValid = isValidAddress && isValidAmount && isMemoValid;
+
+  const handleClose = () => {
+    setTo("");
+    setAmount("");
+    setMemo("");
+    setSubmitError(null);
+    onClose();
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isValid) {
-      setError("Please fill in all fields correctly.");
+      setSubmitError("Please fill in all fields correctly.");
       return;
     }
 
     try {
-      setError(null);
+      setSubmitError(null);
       const stroops = parseXlmToStroops(amount);
       await onPropose(normalizedRecipient, stroops, memo.trim());
-      onClose();
-      // Reset form
-      setTo("");
-      setAmount("");
-      setMemo("");
-    } catch (err: any) {
-      setError(err.message || "Failed to propose withdrawal. Please try again.");
+      handleClose();
+    } catch (err: unknown) {
+      setSubmitError(
+        err instanceof Error
+          ? err.message
+          : "Failed to propose withdrawal. Please try again.",
+      );
     }
   };
+
+  const addressHint =
+    to && !isValidAddress
+      ? "Enter a valid Stellar account (G...) or contract (C...) address"
+      : addressType === "contract"
+        ? "Contract address"
+        : addressType === "account"
+          ? "Account address"
+          : null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm animate-in fade-in duration-200">
       <div className="bg-white dark:bg-slate-900 rounded-xl shadow-xl w-full max-w-md overflow-hidden border border-slate-200 dark:border-slate-800">
         <div className="p-4 border-b border-slate-200 dark:border-slate-800 flex justify-between items-center">
           <h2 className="text-lg font-semibold">Propose Withdrawal</h2>
-          <button onClick={onClose} className="p-1 text-slate-500 hover:text-slate-900 dark:hover:text-white rounded-full transition-colors">
+          <button
+            onClick={handleClose}
+            className="p-1 text-slate-500 hover:text-slate-900 dark:hover:text-white rounded-full transition-colors"
+            aria-label="Close modal"
+          >
             <X size={20} />
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
-          <div className="space-y-2">
-            <label htmlFor="to" className="text-sm font-medium">Recipient Address</label>
+        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+          {/* Recipient */}
+          <div className="space-y-1.5">
+            <label htmlFor="wd-to" className="text-sm font-medium">
+              Recipient Address
+            </label>
             <input
-              id="to"
+              id="wd-to"
               type="text"
               placeholder="G... or C..."
               value={to}
               onChange={(e) => {
                 setTo(e.target.value);
-                if (error) setError(null);
+                setSubmitError(null);
               }}
               className={cn(
-                "w-full px-4 py-3 bg-slate-50 dark:bg-slate-950 border rounded-lg focus:outline-none focus:ring-2 transition-all",
-                error && !isValidAddress ? "border-rose-500 focus:ring-rose-500/20" : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 focus:ring-indigo-500/20"
+                "w-full px-4 py-3 bg-slate-50 dark:bg-slate-950 border rounded-lg focus:outline-none focus:ring-2 transition-all font-mono text-sm",
+                to && !isValidAddress
+                  ? "border-rose-500 focus:ring-rose-500/20"
+                  : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 focus:ring-indigo-500/20",
               )}
               disabled={isProposing}
+              autoComplete="off"
+              spellCheck={false}
             />
-            {to && !isValidAddress && <p className="text-sm text-rose-500">Enter a valid Stellar account or contract address</p>}
+            {addressHint && (
+              <p
+                className={cn(
+                  "text-xs",
+                  to && !isValidAddress ? "text-rose-500" : "text-slate-400",
+                )}
+              >
+                {addressHint}
+              </p>
+            )}
           </div>
 
-          <div className="space-y-2">
+          {/* Amount */}
+          <div className="space-y-1.5">
             <div className="flex justify-between items-center">
-              <label htmlFor="amount" className="text-sm font-medium">Amount to Withdraw</label>
-              <span className="text-xs text-slate-500">Balance: {balanceXlm.toFixed(7)} XLM</span>
+              <label htmlFor="wd-amount" className="text-sm font-medium">
+                Amount
+              </label>
+              <span className="text-xs text-slate-500">
+                Balance: {balanceXlm.toFixed(7)} XLM
+              </span>
             </div>
             <div className="relative">
               <input
-                id="amount"
+                id="wd-amount"
                 type="text"
                 placeholder="0.00"
                 value={amount}
                 onChange={(e) => {
                   setAmount(e.target.value);
-                  if (error) setError(null);
+                  setSubmitError(null);
                 }}
                 className={cn(
-                  "w-full px-4 py-3 bg-slate-50 dark:bg-slate-950 border rounded-lg focus:outline-none focus:ring-2 transition-all",
-                  error && !isValidAmount ? "border-rose-500 focus:ring-rose-500/20" : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 focus:ring-indigo-500/20"
+                  "w-full px-4 py-3 pr-14 bg-slate-50 dark:bg-slate-950 border rounded-lg focus:outline-none focus:ring-2 transition-all",
+                  amount && !isValidAmount
+                    ? "border-rose-500 focus:ring-rose-500/20"
+                    : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 focus:ring-indigo-500/20",
                 )}
                 disabled={isProposing}
               />
-              <div className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 font-medium">
+              <span className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm pointer-events-none">
                 XLM
-              </div>
+              </span>
             </div>
-            {amount && !isValidAmount && <p className="text-sm text-rose-500">Amount must be positive and not exceed balance</p>}
+            {amount && !isValidAmount && (
+              <p className="text-xs text-rose-500">
+                {amountNum <= 0
+                  ? "Amount must be greater than zero"
+                  : amountNum > balanceXlm
+                    ? "Amount exceeds available balance"
+                    : "Enter a valid number"}
+              </p>
+            )}
           </div>
 
-          <div className="space-y-2">
-            <label htmlFor="memo" className="text-sm font-medium">Memo (Description)</label>
+          {/* Memo */}
+          <div className="space-y-1.5">
+            <div className="flex justify-between items-center">
+              <label htmlFor="wd-memo" className="text-sm font-medium">
+                Memo
+              </label>
+              <span
+                className={cn(
+                  "text-xs tabular-nums",
+                  memoBytes > MEMO_MAX_BYTES
+                    ? "text-rose-500"
+                    : "text-slate-400",
+                )}
+              >
+                {memoBytes}/{MEMO_MAX_BYTES}
+              </span>
+            </div>
             <input
-              id="memo"
+              id="wd-memo"
               type="text"
-              placeholder="Purpose of withdrawal..."
+              placeholder="Purpose of withdrawal…"
               value={memo}
               onChange={(e) => {
                 setMemo(e.target.value);
-                if (error) setError(null);
+                setSubmitError(null);
               }}
               className={cn(
                 "w-full px-4 py-3 bg-slate-50 dark:bg-slate-950 border rounded-lg focus:outline-none focus:ring-2 transition-all",
-                error && !memo.trim() ? "border-rose-500 focus:ring-rose-500/20" : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 focus:ring-indigo-500/20"
+                memo && !isMemoValid
+                  ? "border-rose-500 focus:ring-rose-500/20"
+                  : "border-slate-200 dark:border-slate-800 focus:border-indigo-500 focus:ring-indigo-500/20",
               )}
               disabled={isProposing}
             />
-            {memo && !memo.trim() && <p className="text-sm text-rose-500">Memo is required</p>}
+            {memo && memoBytes > MEMO_MAX_BYTES && (
+              <p className="text-xs text-rose-500">
+                Memo exceeds {MEMO_MAX_BYTES}-byte limit (Stellar text memo
+                constraint)
+              </p>
+            )}
+            {memo && memo.trim().length === 0 && (
+              <p className="text-xs text-rose-500">Memo cannot be blank</p>
+            )}
           </div>
 
-          {error && <p className="text-sm text-rose-500">{error}</p>}
+          {/* Submit error */}
+          {submitError && (
+            <p className="text-sm text-rose-500 bg-rose-500/10 border border-rose-500/20 rounded-lg px-3 py-2">
+              {submitError}
+            </p>
+          )}
 
           <button
             type="submit"
@@ -138,8 +243,8 @@ export function WithdrawalModal({ isOpen, onClose, onPropose, balance, isProposi
           >
             {isProposing ? (
               <>
-                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
-                Proposing...
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                Proposing…
               </>
             ) : (
               "Propose Withdrawal"

--- a/frontend/src/hooks/useGovernance.ts
+++ b/frontend/src/hooks/useGovernance.ts
@@ -19,12 +19,10 @@ import {
   type GovernanceProposal,
   type GovernanceProposalAction,
 } from "@/lib/contractData";
-import {
-  createLatestRequestGuard,
-  isAbortError,
-} from "@/lib/requestGuard";
+import { createLatestRequestGuard, isAbortError } from "@/lib/requestGuard";
 import { classifyError, type AppError } from "@/lib/errors";
 import { useFreighter } from "./useFreighter";
+import { usePageVisibility } from "./usePageVisibility";
 
 const REFRESH_INTERVAL = 30_000;
 
@@ -39,15 +37,16 @@ export interface PendingVote {
 
 export function useGovernance() {
   const { address } = useFreighter();
+  const isPageVisible = usePageVisibility();
   const [config, setConfig] = useState<GovernanceConfig | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<AppError | null>(null);
 
   // Maps proposalId → voteFor for votes that are in-flight.
   // UI reads this to reflect intent before chain confirmation.
-  const [pendingVotes, setPendingVotes] = useState<ReadonlyMap<number, boolean>>(
-    new Map(),
-  );
+  const [pendingVotes, setPendingVotes] = useState<
+    ReadonlyMap<number, boolean>
+  >(new Map());
 
   const requestGuardRef = useRef(createLatestRequestGuard());
 
@@ -187,8 +186,9 @@ export function useGovernance() {
 
     // Optimistically record the pending vote so the UI reflects intent
     // instantly — the counter updates before the chain confirms.
-    setPendingVotes((prev: ReadonlyMap<number, boolean>) =>
-      new Map(Array.from(prev).concat([[proposalId, voteFor]])),
+    setPendingVotes(
+      (prev: ReadonlyMap<number, boolean>) =>
+        new Map(Array.from(prev).concat([[proposalId, voteFor]])),
     );
 
     const request = requestGuardRef.current.begin();
@@ -340,13 +340,18 @@ export function useGovernance() {
 
   useEffect(() => {
     refresh();
-    const interval = setInterval(refresh, REFRESH_INTERVAL);
+    const interval = setInterval(() => {
+      // Pause polling while the tab is hidden to avoid unnecessary RPC calls.
+      if (isPageVisible) {
+        refresh();
+      }
+    }, REFRESH_INTERVAL);
 
     return () => {
       clearInterval(interval);
       requestGuardRef.current.cancel("Governance refresh cancelled.");
     };
-  }, [refresh]);
+  }, [refresh, isPageVisible]);
 
   useEffect(() => {
     return () => {

--- a/frontend/src/hooks/usePageVisibility.ts
+++ b/frontend/src/hooks/usePageVisibility.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Returns true when the page is visible (document.visibilityState === "visible").
+ * Useful for pausing polling loops while the tab is hidden to avoid unnecessary
+ * network traffic and stale-update races.
+ */
+export function usePageVisibility(): boolean {
+  const [isVisible, setIsVisible] = useState<boolean>(
+    typeof document !== "undefined"
+      ? document.visibilityState === "visible"
+      : true,
+  );
+
+  useEffect(() => {
+    const handleChange = () => {
+      setIsVisible(document.visibilityState === "visible");
+    };
+
+    document.addEventListener("visibilitychange", handleChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleChange);
+    };
+  }, []);
+
+  return isVisible;
+}

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -22,6 +22,7 @@ import { classifyError, type AppError } from "@/lib/errors";
 import { createLatestRequestGuard, isAbortError } from "@/lib/requestGuard";
 import { isWalletNetworkMismatch } from "@/lib/network";
 import { useFreighter } from "./useFreighter";
+import { usePageVisibility } from "./usePageVisibility";
 
 const REFRESH_INTERVAL = 30_000;
 const MAX_VISIBLE_TRANSACTIONS = 20;
@@ -30,6 +31,7 @@ type TxAction = "approve" | "execute";
 
 export function useTreasury() {
   const { address, network } = useFreighter();
+  const isPageVisible = usePageVisibility();
   const [balance, setBalance] = useState<bigint>(BigInt(0));
   const [config, setConfig] = useState<TreasuryConfig | null>(null);
   const [transactions, setTransactions] = useState<TreasuryTransaction[]>([]);
@@ -162,7 +164,11 @@ export function useTreasury() {
         fetchConfig(request.id, request.signal),
       ]);
 
-      await fetchTransactions(request.id, request.signal, currentConfig.txCount);
+      await fetchTransactions(
+        request.id,
+        request.signal,
+        currentConfig.txCount,
+      );
 
       if (requestGuardRef.current.isCurrent(request.id)) {
         setBalance(currentConfig.balance ?? currentBalance);
@@ -212,7 +218,11 @@ export function useTreasury() {
   );
 
   const proposeWithdrawal = useCallback(
-    async (to: string, amount: bigint | number, memo: string): Promise<void> => {
+    async (
+      to: string,
+      amount: bigint | number,
+      memo: string,
+    ): Promise<void> => {
       assertWalletReady();
       const walletAddress = address as string;
       setError(null);
@@ -263,7 +273,9 @@ export function useTreasury() {
         setTxAction(txId, null);
         throw new Error("You already approved this transaction");
       }
-      if (tx.approvals.length >= (config?.threshold ?? Number.MAX_SAFE_INTEGER)) {
+      if (
+        tx.approvals.length >= (config?.threshold ?? Number.MAX_SAFE_INTEGER)
+      ) {
         setTxAction(txId, null);
         throw new Error("Approval threshold already met");
       }
@@ -302,7 +314,14 @@ export function useTreasury() {
         setTxAction(txId, null);
       }
     },
-    [address, assertWalletReady, config?.threshold, refresh, setTxAction, transactions],
+    [
+      address,
+      assertWalletReady,
+      config?.threshold,
+      refresh,
+      setTxAction,
+      transactions,
+    ],
   );
 
   const execute = useCallback(
@@ -340,14 +359,17 @@ export function useTreasury() {
     refresh();
 
     const interval = setInterval(() => {
-      refresh();
+      // Pause polling while the tab is hidden to avoid unnecessary RPC calls.
+      if (isPageVisible) {
+        refresh();
+      }
     }, REFRESH_INTERVAL);
 
     return () => {
       clearInterval(interval);
       requestGuard.cancel("Treasury refresh cancelled.");
     };
-  }, [refresh]);
+  }, [refresh, isPageVisible]);
 
   useEffect(() => {
     const requestGuard = requestGuardRef.current;

--- a/frontend/src/lib/contractData.test.ts
+++ b/frontend/src/lib/contractData.test.ts
@@ -46,6 +46,33 @@ describe("contract decoders", () => {
       approvals: ["GS1", "GS2"],
       executed: false,
       createdAt: 1700,
+      executedAt: null,
+      proposer: "GPROP",
+    });
+  });
+
+  it("decodes treasury transactions with executedAt timestamp", () => {
+    expect(
+      decodeTreasuryTransaction({
+        id: "8",
+        to: "GDEST",
+        amount: BigInt(2000000),
+        memo: "payout",
+        approvals: ["GS1"],
+        executed: true,
+        created_at: 1700,
+        executed_at: 1800,
+        proposer: "GPROP",
+      }),
+    ).toEqual({
+      id: 8,
+      to: "GDEST",
+      amount: BigInt(2000000),
+      memo: "payout",
+      approvals: ["GS1"],
+      executed: true,
+      createdAt: 1700,
+      executedAt: 1800,
       proposer: "GPROP",
     });
   });
@@ -154,6 +181,7 @@ describe("treasury integration tests with mocked Soroban responses", () => {
       approvals: [],
       executed: false,
       createdAt: 1700000000,
+      executedAt: null,
       proposer: "GPROP1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     });
   });

--- a/frontend/src/lib/contractData.ts
+++ b/frontend/src/lib/contractData.ts
@@ -48,6 +48,8 @@ export interface TreasuryTransaction {
   approvals: string[];
   executed: boolean;
   createdAt: number;
+  /** Unix timestamp (seconds) when the transaction was executed on-chain. Null if not yet executed. */
+  executedAt: number | null;
   proposer: string;
 }
 
@@ -249,6 +251,15 @@ export const decodeTreasuryTransaction: Decoder<TreasuryTransaction> = (
 ) => {
   const record = asRecord(value, "treasury transaction");
 
+  // executed_at is optional — contracts may not emit it for pending txs
+  let executedAt: number | null = null;
+  if ("executed_at" in record && record["executed_at"] != null) {
+    executedAt = toSafeNumber(
+      record["executed_at"],
+      "treasury transaction executed_at",
+    );
+  }
+
   return {
     id: toSafeNumber(readField(record, "id"), "treasury transaction id"),
     to: toStringValue(readField(record, "to"), "treasury transaction to"),
@@ -269,6 +280,7 @@ export const decodeTreasuryTransaction: Decoder<TreasuryTransaction> = (
       readField(record, "created_at"),
       "treasury transaction created_at",
     ),
+    executedAt,
     proposer: toStringValue(
       readField(record, "proposer"),
       "treasury transaction proposer",
@@ -280,10 +292,7 @@ export const decodeGovernanceConfig: Decoder<GovernanceConfig> = (value) => {
   const record = asRecord(value, "governance config");
 
   return {
-    admin: toStringValue(
-      readField(record, "admin"),
-      "governance config admin",
-    ),
+    admin: toStringValue(readField(record, "admin"), "governance config admin"),
     memberCount: toSafeNumber(
       readField(record, "member_count"),
       "governance config member_count",
@@ -310,7 +319,10 @@ export const decodeGovernanceProposal: Decoder<GovernanceProposal> = (
 
   return {
     id: toSafeNumber(readField(record, "id"), "governance proposal id"),
-    title: toStringValue(readField(record, "title"), "governance proposal title"),
+    title: toStringValue(
+      readField(record, "title"),
+      "governance proposal title",
+    ),
     description: toStringValue(
       readField(record, "description"),
       "governance proposal description",

--- a/frontend/src/lib/pageVisibility.test.ts
+++ b/frontend/src/lib/pageVisibility.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Tests for the page-visibility pause logic used in useTreasury and
+ * useGovernance. We test the pure polling guard logic that doesn't require
+ * a DOM environment (vitest is configured with environment: "node").
+ */
+
+describe("page visibility pause logic", () => {
+  it("polling guard: refresh is skipped when page is hidden", () => {
+    const refresh = vi.fn();
+    let isPageVisible = false;
+
+    // Mirrors the interval callback in useTreasury / useGovernance
+    const intervalCallback = () => {
+      if (isPageVisible) {
+        refresh();
+      }
+    };
+
+    intervalCallback();
+    expect(refresh).not.toHaveBeenCalled();
+
+    isPageVisible = true;
+    intervalCallback();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("polling guard: refresh runs every tick when page is visible", () => {
+    const refresh = vi.fn();
+    const isPageVisible = true;
+
+    const intervalCallback = () => {
+      if (isPageVisible) {
+        refresh();
+      }
+    };
+
+    intervalCallback();
+    intervalCallback();
+    intervalCallback();
+    expect(refresh).toHaveBeenCalledTimes(3);
+  });
+
+  it("polling guard: refresh stops when page becomes hidden mid-session", () => {
+    const refresh = vi.fn();
+    let isPageVisible = true;
+
+    const intervalCallback = () => {
+      if (isPageVisible) {
+        refresh();
+      }
+    };
+
+    intervalCallback(); // visible → refresh
+    isPageVisible = false;
+    intervalCallback(); // hidden → skip
+    intervalCallback(); // hidden → skip
+    isPageVisible = true;
+    intervalCallback(); // visible again → refresh
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Issues Resolved

### [FE-165] Wire Vote For/Against buttons to contract transactions #148

**Problem:** `VoteButton` used the global `isLoading` flag from `useGovernance`, which disabled all vote buttons across all proposals whenever any governance operation was in flight.

**Changes:**

- `frontend/src/components/VoteButton.tsx` — replaced `isLoading` with `pendingVotes.has(proposalId)` for per-proposal pending state
- Vote buttons on other proposals remain enabled while one vote is in flight
- Disabled states correctly reflect: already voted, voting closed, wallet disconnected, pending confirmation
- Toast success/failure feedback unchanged and working

---

### [FE-154] Show finality and confirmation timestamp for each tx #137

**Problem:** Treasury execution history only showed a single "Time" column (proposal creation time). There was no way to see when a transaction was actually confirmed on-chain.

**Changes:**

- `frontend/src/lib/contractData.ts` — added `executedAt: number | null` field to `TreasuryTransaction` interface; updated `decodeTreasuryTransaction` to decode optional `executed_at` field from contract response (null when absent/pending)
- `frontend/src/app/treasury/page.tsx` — execution history table now has "Proposed" and "Confirmed" columns; transaction detail sidebar shows "Confirmed on-chain" timestamp in green when available
- `frontend/src/lib/contractData.test.ts` — updated existing decoder tests to include `executedAt: null`; added new test for `executedAt` with timestamp

---

### [FE-153] Implement auto-refresh with pause-on-tab-hidden behavior #136

**Problem:** Both `useTreasury` and `useGovernance` polled every 30 seconds unconditionally, including when the browser tab was hidden, wasting RPC calls and risking stale-update races.

**Changes:**

- `frontend/src/hooks/usePageVisibility.ts` — new hook that tracks `document.visibilityState` via `visibilitychange` event; returns `true` when tab is visible
- `frontend/src/hooks/useTreasury.ts` — imports `usePageVisibility`; interval callback skips `refresh()` when `isPageVisible === false`
- `frontend/src/hooks/useGovernance.ts` — same integration
- `frontend/src/lib/pageVisibility.test.ts` — 3 unit tests covering the polling guard logic (hidden skips, visible runs, mid-session toggle)

---

### [FE-143] Implement propose withdrawal modal with address/memo validation #126

**Problem:** `WithdrawalModal` had basic validation but lacked memo byte-length enforcement (Stellar text memo max is 28 bytes), address type feedback, and clear per-field error messages.

**Changes:**

- `frontend/src/components/WithdrawalModal.tsx` — full rewrite with:
  - Live byte counter for memo field (`{n}/28`) that turns red when over limit
  - Memo validated against 28-byte UTF-8 limit (Stellar protocol constraint)
  - Address type hint: shows "Account address" or "Contract address" for valid inputs, error for invalid
  - Per-field amount error messages: "must be greater than zero" vs "exceeds available balance"
  - Submit error displayed in styled error box above submit button
  - Form state resets on close (both X button and after successful submit)
  - `aria-label` on close button for accessibility
  - Uses `getStellarAddressType` from `stellarAddress.ts` for richer feedback

---

## Files Changed

| File                                          | Change                                |
| --------------------------------------------- | ------------------------------------- |
| `frontend/src/components/VoteButton.tsx`      | Per-proposal pending state            |
| `frontend/src/components/WithdrawalModal.tsx` | Robust validation rewrite             |
| `frontend/src/hooks/useGovernance.ts`         | Pause-on-tab-hidden integration       |
| `frontend/src/hooks/useTreasury.ts`           | Pause-on-tab-hidden integration       |
| `frontend/src/hooks/usePageVisibility.ts`     | New hook (created)                    |
| `frontend/src/lib/contractData.ts`            | `executedAt` field + decoder          |
| `frontend/src/lib/contractData.test.ts`       | Updated + new decoder tests           |
| `frontend/src/lib/pageVisibility.test.ts`     | New test file (created)               |
| `frontend/src/app/treasury/page.tsx`          | Confirmed timestamp columns + sidebar |

## Test Results

```
 ✓ src/lib/pageVisibility.test.ts  (3 tests)
 ✓ src/lib/requestGuard.test.ts    (4 tests)
 ✓ src/lib/contractData.test.ts    (13 tests)
 ✓ src/lib/formatters.test.ts      (10 tests)

 Test Files  4 passed (4)
      Tests  30 passed (30)
```
Closes #148 
Closes #137
Closes #136
Closes #126