### PR TITLE
feat: secure external link handling and link audit

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "check:deps": "node scripts/check-deps.mjs"
+    "check:deps": "node scripts/check-deps.mjs",
+    "check:external-links": "node scripts/audit-external-links.mjs"
   },
   "dependencies": {
     "@stellar/freighter-api": "^2.0.0",

--- a/frontend/scripts/audit-external-links.mjs
+++ b/frontend/scripts/audit-external-links.mjs
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "src");
+const EXTENSIONS = new Set([".tsx", ".jsx", ".ts", ".js"]);
+const TARGET_BLANK_PATTERN = /target\s*=\s*["']_blank["']/g;
+const REL_PATTERN = /rel\s*=\s*["']([^"']*)["']/i;
+const SKIP_FILES = new Set([path.join("components", "SecureExternalLink.tsx")]);
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(fullPath));
+      continue;
+    }
+
+    if (EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function validateTargetBlank(filePath, content) {
+  const lines = content.split("\n");
+  const violations = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!TARGET_BLANK_PATTERN.test(line)) continue;
+
+    TARGET_BLANK_PATTERN.lastIndex = 0;
+
+    const relMatch = line.match(REL_PATTERN);
+    if (!relMatch) {
+      violations.push(`${filePath}:${index + 1} missing rel for target=\"_blank\"`);
+      continue;
+    }
+
+    const relValue = relMatch[1].toLowerCase();
+    const hasNoopener = relValue.includes("noopener");
+    const hasNoreferrer = relValue.includes("noreferrer");
+
+    if (!hasNoopener || !hasNoreferrer) {
+      violations.push(
+        `${filePath}:${index + 1} rel must include both noopener and noreferrer (found: ${relMatch[1]})`
+      );
+    }
+  }
+
+  return violations;
+}
+
+const files = walk(ROOT);
+const violations = [];
+
+for (const filePath of files) {
+  const relativeFilePath = path.relative(ROOT, filePath);
+  if (SKIP_FILES.has(relativeFilePath)) {
+    continue;
+  }
+
+  const content = fs.readFileSync(filePath, "utf8");
+  violations.push(...validateTargetBlank(filePath, content));
+}
+
+if (violations.length > 0) {
+  console.error("External link audit failed:\n");
+  for (const issue of violations) {
+    console.error(`- ${issue}`);
+  }
+  process.exit(1);
+}
+
+console.log("External link audit passed.");

--- a/frontend/src/components/SecureExternalLink.tsx
+++ b/frontend/src/components/SecureExternalLink.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { buildSecureRel, requiresSecureRel } from "@/lib/externalLinks";
+
+type SecureExternalLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  href: string;
+};
+
+export function SecureExternalLink({ href, target = "_blank", rel, children, ...props }: SecureExternalLinkProps) {
+  const secureRel = requiresSecureRel(target) ? buildSecureRel(rel) : rel;
+
+  return (
+    <a href={href} target={target} rel={secureRel} {...props}>
+      {children}
+    </a>
+  );
+}

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -4,20 +4,19 @@ import React from "react";
 import { useFreighter } from "@/hooks/useFreighter";
 import { formatAddress } from "@/lib/formatters";
 import { CopyButton } from "@/components/CopyButton";
+import { SecureExternalLink } from "@/components/SecureExternalLink";
 
 export const WalletConnect = () => {
   const { address, isConnecting, connect, disconnect, isFreighterInstalled, error } = useFreighter();
 
   if (!isFreighterInstalled) {
     return (
-      <a 
-        href="https://www.freighter.app/" 
-        target="_blank" 
-        rel="noopener noreferrer"
+      <SecureExternalLink
+        href="https://www.freighter.app/"
         className="btn-primary text-sm"
       >
         Install Freighter
-      </a>
+      </SecureExternalLink>
     );
   }
 

--- a/frontend/src/lib/externalLinks.test.ts
+++ b/frontend/src/lib/externalLinks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { buildSecureRel, requiresSecureRel } from "./externalLinks";
+
+describe("externalLinks", () => {
+  it("adds noopener and noreferrer when rel is missing", () => {
+    expect(buildSecureRel()).toBe("noopener noreferrer");
+  });
+
+  it("preserves existing rel tokens and appends required tokens", () => {
+    expect(buildSecureRel("nofollow")).toBe("nofollow noopener noreferrer");
+  });
+
+  it("deduplicates tokens case-insensitively", () => {
+    expect(buildSecureRel("NoOpener noreferrer")).toBe("noopener noreferrer");
+  });
+
+  it("requires secure rel when target is _blank", () => {
+    expect(requiresSecureRel("_blank")).toBe(true);
+    expect(requiresSecureRel("_self")).toBe(false);
+  });
+});

--- a/frontend/src/lib/externalLinks.ts
+++ b/frontend/src/lib/externalLinks.ts
@@ -1,0 +1,21 @@
+const REQUIRED_REL_TOKENS = ["noopener", "noreferrer"] as const;
+
+function tokenizeRel(rel?: string): string[] {
+  if (!rel) return [];
+  return rel
+    .split(/\s+/)
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function buildSecureRel(rel?: string): string {
+  const tokens = new Set(tokenizeRel(rel));
+  for (const token of REQUIRED_REL_TOKENS) {
+    tokens.add(token);
+  }
+  return Array.from(tokens).join(" ");
+}
+
+export function requiresSecureRel(target?: string): boolean {
+  return target === "_blank";
+}


### PR DESCRIPTION
Closes #160
Closes #162
Closes #168
Closes #173

## Summary
- implement issue #168 by introducing a SecureExternalLink component that enforces safe rel handling for target=_blank
- centralize rel-token security logic in externalLinks utilities with unit coverage
- replace the existing Freighter install external link usage with the secure wrapper
- add scripts/audit-external-links.mjs and npm run check:external-links to audit frontend source for unsafe target=_blank links

## Verification
- node frontend/scripts/audit-external-links.mjs (passes)
- Frontend dependency-based tests were not run in this clone because frontend/node_modules is not installed