### PR TITLE
fix: resolve multiple issues - migration CLI, event schema, graceful shutdown, type safety

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -49,3 +49,15 @@ This directory contains PostgreSQL migration scripts for the StellarGuard backen
 - Addresses are stored as text (Stellar public keys)
 - Timestamps use TIMESTAMP WITH TIME ZONE for UTC storage
 - JSONB fields store structured data (proposal actions, transaction approvals)
+
+## Migration Workflow
+
+Run the database migration script to initialize or update the schema:
+
+```bash
+npm run migrate
+```
+
+This creates the following tables:
+- `events`: Stores contract events with topic_1, topic_2, event_name, event_topics, and event_data columns
+- `event_cursor`: Tracks the last processed event cursor for resumable polling

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { GovernanceController } from "./governance/governance.controller";
 import { GovernanceService } from "./governance/governance.service";
 import { VaultController } from "./vault/vault.controller";
 import { VaultService } from "./vault/vault.service";
+import { ListenerService } from "./listener.service";
 
 @Module({
   imports: [],
@@ -15,6 +16,6 @@ import { VaultService } from "./vault/vault.service";
     GovernanceController,
     VaultController,
   ],
-  providers: [TreasuryService, GovernanceService, VaultService],
+  providers: [TreasuryService, GovernanceService, VaultService, ListenerService],
 })
 export class AppModule {}

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -11,6 +11,8 @@ CREATE TABLE IF NOT EXISTS events (
   contract_id TEXT NOT NULL,
   topic_1 TEXT,
   topic_2 TEXT,
+  event_name TEXT,
+  event_topics JSONB,
   event_data JSONB,
   ledger INTEGER NOT NULL,
   timestamp BIGINT,
@@ -22,6 +24,7 @@ CREATE INDEX IF NOT EXISTS idx_events_contract ON events(contract_id);
 CREATE INDEX IF NOT EXISTS idx_events_topics ON events(topic_1, topic_2);
 CREATE INDEX IF NOT EXISTS idx_events_ledger ON events(ledger);
 CREATE INDEX IF NOT EXISTS idx_events_cursor ON events(cursor);
+CREATE INDEX IF NOT EXISTS idx_events_name ON events(event_name);
 
 CREATE TABLE IF NOT EXISTS event_cursor (
   id INTEGER PRIMARY KEY DEFAULT 1,
@@ -45,6 +48,8 @@ export interface StoredEvent {
   contract_id: string;
   topic_1: string | null;
   topic_2: string | null;
+  event_name: string | null;
+  event_topics: unknown[] | null;
   event_data: Record<string, unknown>;
   ledger: number;
   timestamp: number | null;
@@ -53,12 +58,14 @@ export interface StoredEvent {
 
 export async function insertEvent(event: StoredEvent): Promise<void> {
   await pool.query(
-    `INSERT INTO events (contract_id, topic_1, topic_2, event_data, ledger, timestamp, cursor)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    `INSERT INTO events (contract_id, topic_1, topic_2, event_name, event_topics, event_data, ledger, timestamp, cursor)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
     [
       event.contract_id,
       event.topic_1,
       event.topic_2,
+      event.event_name,
+      event.event_topics ? JSON.stringify(event.event_topics) : null,
       JSON.stringify(event.event_data),
       event.ledger,
       event.timestamp,
@@ -75,12 +82,14 @@ export async function insertEvents(events: StoredEvent[]): Promise<void> {
     await client.query("BEGIN");
     for (const event of events) {
       await client.query(
-        `INSERT INTO events (contract_id, topic_1, topic_2, event_data, ledger, timestamp, cursor)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+        `INSERT INTO events (contract_id, topic_1, topic_2, event_name, event_topics, event_data, ledger, timestamp, cursor)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
         [
           event.contract_id,
           event.topic_1,
           event.topic_2,
+          event.event_name,
+          event.event_topics ? JSON.stringify(event.event_topics) : null,
           JSON.stringify(event.event_data),
           event.ledger,
           event.timestamp,
@@ -125,15 +134,4 @@ export async function updateCursor(
   );
 }
 
-// When run directly, initialize the schema
-if (require.main === module) {
-  initializeSchema()
-    .then(() => {
-      console.log("Migration complete.");
-      process.exit(0);
-    })
-    .catch((err) => {
-      console.error("Migration failed:", err);
-      process.exit(1);
-    });
-}
+

--- a/backend/src/listener.service.ts
+++ b/backend/src/listener.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from "@nestjs/common";
+import { startListener, stopListener, setupSignalHandlers } from "./listener";
+
+@Injectable()
+export class ListenerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ListenerService.name);
+
+  async onModuleInit() {
+    setupSignalHandlers();
+    this.logger.log("Starting event listener...");
+    startListener().catch((err) => {
+      this.logger.error("Event listener failed:", err);
+    });
+  }
+
+  async onModuleDestroy() {
+    this.logger.log("Stopping event listener...");
+    stopListener();
+  }
+}

--- a/backend/src/listener.ts
+++ b/backend/src/listener.ts
@@ -10,8 +10,10 @@ import { parseRawEvent, ParsedEvent } from "./parser";
 
 const MAX_BACKOFF_MS = 30_000;
 const BASE_BACKOFF_MS = 1_000;
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10_000;
 
 let running = true;
+let shutdownForced = false;
 
 /**
  * Convert a ParsedEvent to a StoredEvent for database insertion.
@@ -21,6 +23,8 @@ function toStoredEvent(parsed: ParsedEvent): StoredEvent {
     contract_id: parsed.contractId,
     topic_1: parsed.topic1,
     topic_2: parsed.topic2,
+    event_name: parsed.eventName,
+    event_topics: parsed.eventTopics,
     event_data: parsed.data,
     ledger: parsed.ledger,
     timestamp: parsed.timestamp,
@@ -108,7 +112,7 @@ async function pollEvents(
   }
 
   for (const parsed of parsedEvents) {
-    const eventName = parsed.data._eventName || `${parsed.topic1}:${parsed.topic2}`;
+    const eventName = parsed.eventName || `${parsed.topic1}:${parsed.topic2}`;
     console.log(
       `[Ledger ${parsed.ledger}] ${eventName} from ${parsed.contractId}`
     );
@@ -184,4 +188,43 @@ export async function startListener(): Promise<void> {
  */
 export function stopListener(): void {
   running = false;
+}
+
+/**
+ * Wait for in-flight events to complete, then resolve.
+ */
+export async function waitForCompletion(): Promise<void> {
+  return new Promise((resolve) => {
+    const checkInterval = setInterval(() => {
+      if (!running || shutdownForced) {
+        clearInterval(checkInterval);
+        resolve();
+      }
+    }, 100);
+
+    setTimeout(() => {
+      clearInterval(checkInterval);
+      shutdownForced = true;
+      resolve();
+    }, GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+  });
+}
+
+/**
+ * Handle process signals for graceful shutdown.
+ */
+export function setupSignalHandlers(): void {
+  process.on("SIGTERM", async () => {
+    console.log("Received SIGTERM, shutting down gracefully...");
+    stopListener();
+    await waitForCompletion();
+    process.exit(0);
+  });
+
+  process.on("SIGINT", async () => {
+    console.log("Received SIGINT, shutting down gracefully...");
+    stopListener();
+    await waitForCompletion();
+    process.exit(0);
+  });
 }

--- a/backend/src/migrate.ts
+++ b/backend/src/migrate.ts
@@ -1,0 +1,11 @@
+import { initializeSchema } from "./db";
+
+initializeSchema()
+  .then(() => {
+    console.log("Migration complete.");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("Migration failed:", err);
+    process.exit(1);
+  });

--- a/backend/src/parser.ts
+++ b/backend/src/parser.ts
@@ -19,6 +19,8 @@ export interface ParsedEvent {
   contractId: string;
   topic1: string | null;
   topic2: string | null;
+  eventName: string | null;
+  eventTopics: unknown[] | null;
   data: Record<string, unknown>;
   ledger: number;
   timestamp: number | null;
@@ -116,15 +118,13 @@ export function parseRawEvent(rawEvent: {
   const data = parseEventData(rawEvent.value);
 
   const eventName = getEventName(topic1, topic2);
-  if (eventName) {
-    data._eventName = eventName;
-  }
-  data._topics = allTopics;
 
   return {
     contractId: rawEvent.contractId,
     topic1,
     topic2,
+    eventName,
+    eventTopics: allTopics,
     data,
     ledger: rawEvent.ledger,
     timestamp: null,

--- a/backend/src/treasury/treasury.service.ts
+++ b/backend/src/treasury/treasury.service.ts
@@ -10,6 +10,8 @@ export const TransactionSchema = z.object({
   contract_id: z.string(),
   topic_1: z.string().nullable(),
   topic_2: z.string().nullable(),
+  event_name: z.string().nullable(),
+  event_topics: z.any(),
   event_data: z.any(),
   ledger: z.number(),
   timestamp: z.number().nullable(),

--- a/frontend/src/context/FreighterProvider.tsx
+++ b/frontend/src/context/FreighterProvider.tsx
@@ -7,6 +7,7 @@ import {
   getPublicKey,
   getNetwork,
 } from "@stellar/freighter-api";
+import { classifyError, AppError, isAppError } from "@/lib/errors";
 
 export interface FreighterContextType {
   address: string | null;
@@ -76,8 +77,9 @@ export const FreighterProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       } else {
         setError("User denied access");
       }
-    } catch (err: any) {
-      setError(err.message || "Failed to connect to Freighter");
+    } catch (err) {
+      const classified = classifyError(err);
+      setError(classified.message || "Failed to connect to Freighter");
     } finally {
       setIsConnecting(false);
     }


### PR DESCRIPTION
## Summary
- **BE-17**: Move migration logic to separate CLI script (`src/migrate.ts`) and remove `require.main` check from db.ts
- **BE-14**: Add `event_name` TEXT and `event_topics` JSONB columns to events table; store parsed metadata separately from raw contract data
- **BE-13**: Add SIGTERM/SIGINT handlers for graceful shutdown; integrate listener with NestJS lifecycle via `ListenerService`
- **SEC-4**: Replace `err: any` with `classifyError` utility for type-safe error handling in FreighterProvider

Closes #200
Closes #197
Closes #196
Closes #192