### PR TITLE
fix: resolve docker-compose port, env files, and a11y issues

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,16 +1,36 @@
-# Database
+# Docker Environment Configuration for StellarGuard
+# This file is used by docker-compose.yml for development
+
+# Backend Configuration
+PORT=8000
+NODE_ENV=development
+
+# Database Configuration
 POSTGRES_USER=stellarguard
 POSTGRES_PASSWORD=password
 POSTGRES_DB=stellarguard
 DATABASE_URL=postgresql://stellarguard:password@postgres:5432/stellarguard
 
-# Redis
+# Redis Configuration
 REDIS_URL=redis://redis:6379
 
-# Frontend
+# Stellar Configuration
+STELLAR_NETWORK=testnet
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+HORIZON_URL=https://horizon-testnet.stellar.org
+NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Frontend Configuration
 NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 
-# Backend
-PORT=8000
+# Contract IDs (to be populated after deployment)
+TREASURY_CONTRACT_ID=
+GOVERNANCE_CONTRACT_ID=
+TOKEN_VAULT_CONTRACT_ID=
+ACCESS_CONTROL_CONTRACT_ID=
+
+# API Configuration
+API_KEY=your_api_key_here
+CORS_ORIGIN=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ out/
 .env
 .env.local
 .env.production
+.env.docker
 
 # OS
 .DS_Store

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,10 +1,33 @@
+# Backend Environment Variables Example
+# Copy this file to .env and update with your values
+
+# Server Configuration
+# For local development (non-Docker). Docker Compose overrides this to 8000 via its environment block.
+PORT=3001
+NODE_ENV=development
+
+# Database Configuration
 DATABASE_URL=postgresql://localhost:5432/stellarguard
+POSTGRES_USER=stellarguard
+POSTGRES_PASSWORD=password
+POSTGRES_DB=stellarguard
+
+# Redis Configuration
+REDIS_URL=redis://localhost:6379
+
+# Stellar Configuration
+STELLAR_NETWORK=testnet
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+HORIZON_URL=https://horizon-testnet.stellar.org
 NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Contract IDs (populate after deployment)
 TREASURY_CONTRACT_ID=
 GOVERNANCE_CONTRACT_ID=
 TOKEN_VAULT_CONTRACT_ID=
 ACCESS_CONTROL_CONTRACT_ID=
+
+# API Configuration
 POLL_INTERVAL_MS=5000
 CORS_ORIGIN=http://localhost:3000
 
@@ -15,3 +38,10 @@ CORS_ORIGIN=http://localhost:3000
 API_KEYS=
 
 # Rate limiting is configured in app.module.ts (default: 100 req/min per IP)
+
+# Logging
+LOG_LEVEL=info
+LOG_FORMAT=json
+
+# Development
+DEBUG=stellarguard:*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   frontend:
     build: ./frontend
@@ -14,6 +12,8 @@ services:
     build: ./backend
     ports:
       - "8000:8000"
+    environment:
+      - PORT=8000
     env_file:
       - .env.docker
     depends_on:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,24 @@
+# Frontend Environment Variables Example
+# Copy this file to .env.local and update with your values
+
+# Stellar Configuration
+NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Contract IDs (populate after deployment)
+NEXT_PUBLIC_TREASURY_CONTRACT_ID=
+NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID=
+NEXT_PUBLIC_TOKEN_VAULT_CONTRACT_ID=
+NEXT_PUBLIC_ACCESS_CONTROL_CONTRACT_ID=
+
+# Application Configuration
+NEXT_PUBLIC_APP_NAME=StellarGuard
+NEXT_PUBLIC_APP_VERSION=0.1.0
+
+# Analytics (optional)
+NEXT_PUBLIC_ANALYTICS_ID=
+
+# Feature Flags
+NEXT_PUBLIC_ENABLE_ANALYTICS=false
+NEXT_PUBLIC_ENABLE_DEBUG=true

--- a/frontend/src/components/WalletConnect.tsx
+++ b/frontend/src/components/WalletConnect.tsx
@@ -14,6 +14,7 @@ export const WalletConnect = () => {
       <SecureExternalLink
         href="https://www.freighter.app/"
         className="btn-primary text-sm"
+        aria-label="Install Freighter wallet browser extension"
       >
         Install Freighter
       </SecureExternalLink>
@@ -22,7 +23,7 @@ export const WalletConnect = () => {
 
   if (isConnecting) {
     return (
-      <button disabled className="btn-secondary text-sm opacity-50 cursor-not-allowed">
+      <button disabled className="btn-secondary text-sm opacity-50 cursor-not-allowed" aria-label="Connecting to wallet, please wait">
         Connecting...
       </button>
     );
@@ -42,6 +43,7 @@ export const WalletConnect = () => {
         <button 
           onClick={disconnect}
           className="text-xs text-gray-500 hover:text-white transition-colors"
+          aria-label="Disconnect wallet from StellarGuard"
         >
           Disconnect
         </button>
@@ -50,10 +52,21 @@ export const WalletConnect = () => {
   }
 
   return (
-    <div className="flex flex-col items-end space-y-1">
+    <div 
+      role="status" 
+      aria-live="polite" 
+      aria-atomic="true"
+      className="flex flex-col items-end space-y-1"
+    >
+      <div 
+        className="sr-only"
+      >
+        {address ? `Wallet connected: ${formatAddress(address)}` : 'Wallet not connected'}
+      </div>
       <button 
         onClick={connect}
         className="btn-primary text-sm"
+        aria-label="Connect your Freighter wallet to StellarGuard"
       >
         Connect Wallet
       </button>


### PR DESCRIPTION
## Summary

Resolves four issues across DevOps configuration and frontend accessibility.

## Changes

### #215 [DO-12] — Remove deprecated `version` field
- Removed `version: '3.8'` from [docker-compose.yml](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/docker-compose.yml:0:0-0:0) (ignored and deprecated in Docker Compose v2+)

### #214 [DO-11] — Fix backend port mismatch
- [main.ts](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/backend/src/main.ts:0:0-0:0) defaults to port `3001` (`process.env.PORT || 3001`)
- [docker-compose.yml](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/docker-compose.yml:0:0-0:0) backend service now explicitly sets `PORT=8000` via `environment` block
- [.env.docker](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/.env.docker:0:0-0:0) retains `PORT=8000` for Docker context
- [backend/.env.example](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/backend/.env.example:0:0-0:0) corrected to `PORT=3001` (local dev default) with explanatory comment

### #216 [DO-13] — Create missing `.env` files
- Expanded [.env.docker](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/.env.docker:0:0-0:0) with all required variables and inline documentation
- Created [frontend/.env.example](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/frontend/.env.example:0:0-0:0) with all `NEXT_PUBLIC_*` variables
- Expanded [backend/.env.example](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/backend/.env.example:0:0-0:0) with DATABASE_URL, Redis, Stellar config, contract IDs, logging
- Added [.env.docker](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/.env.docker:0:0-0:0) to [.gitignore](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/.gitignore:0:0-0:0) to prevent accidental secret exposure

### #227 [A11Y-2] — WalletConnect aria attributes
- Added `aria-label` to Install Freighter link, Connecting button, Disconnect button, and Connect Wallet button
- Added `role="status"`, `aria-live="polite"`, `aria-atomic="true"` wrapper for connection state
- Added `sr-only` div announcing wallet connected/disconnected state to screen readers

## Files Changed
- [docker-compose.yml](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/docker-compose.yml:0:0-0:0)
- [.env.docker](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/.env.docker:0:0-0:0)
- [.gitignore](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/.gitignore:0:0-0:0)
- [backend/.env.example](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/backend/.env.example:0:0-0:0)
- [frontend/.env.example](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/frontend/.env.example:0:0-0:0) *(new)*
- [frontend/src/components/WalletConnect.tsx](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/frontend/src/components/WalletConnect.tsx:0:0-0:0)

## Testing
- Verified `version` field absent from [docker-compose.yml](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/docker-compose.yml:0:0-0:0)
- Verified PORT values are consistent across all env files and compose config
- Verified [.env.docker](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/.env.docker:0:0-0:0) is gitignored
- Verified all 5 aria attributes and `aria-live` region present in [WalletConnect.tsx](cci:7://file:///home/nanle/Desktop/OpenSource/drips/stellarguard/frontend/src/components/WalletConnect.tsx:0:0-0:0)

Closes #215
Closes #214
Closes #216
Closes #227
