### PR TITLE
documentation, accessibility, API docs, and DevOps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy Contracts
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deploy:
+    name: Deploy to Testnet
+    runs-on: ubuntu-latest
+    environment: testnet
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            smartcontract/target
+          key: ${{ runner.os }}-cargo-deploy-${{ hashFiles('smartcontract/**/Cargo.lock', 'smartcontract/**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-deploy-
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli
+
+      - name: Configure Stellar deployer identity
+        env:
+          STELLAR_SECRET_KEY: ${{ secrets.STELLAR_DEPLOY_SECRET_KEY }}
+        run: stellar keys add deployer --secret-key "$STELLAR_SECRET_KEY"
+
+      - name: Make deploy script executable
+        run: chmod +x scripts/deploy.sh
+
+      - name: Deploy contracts to testnet
+        run: ./scripts/deploy.sh --network testnet --source deployer
+
+      - name: Upload deployed-contracts.json as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deployed-contracts
+          path: scripts/deployed-contracts.json
+
+      - name: Commit updated deployed-contracts.json
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add scripts/deployed-contracts.json
+          git diff --staged --quiet || git commit -m "chore: update deployed-contracts.json for $TAG_NAME"
+          git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -168,6 +168,57 @@ npm run dev                        # starts API on http://localhost:3001
 
 ---
 
+## 🚀 Deploying Contracts
+
+### Prerequisites
+
+| Tool | Install |
+|------|---------|
+| **Stellar CLI** | `cargo install --locked stellar-cli` |
+| **Rust + wasm32 target** | `rustup target add wasm32-unknown-unknown` |
+
+### One-command Testnet Deploy
+
+```bash
+# Set your deployer identity (Stellar secret key or CLI identity name)
+export DEPLOY_SOURCE=my-deployer-identity
+
+# Run the deploy script
+./scripts/deploy.sh --network testnet --source "$DEPLOY_SOURCE"
+```
+
+The script will:
+1. Build all four contracts with `stellar contract build` (release WASM)
+2. Deploy each contract to the specified network
+3. Write contract IDs to `scripts/deployed-contracts.json`
+4. Print a summary of all deployed contract addresses
+
+### Copy Contract IDs to Frontend
+
+After deployment, copy the printed IDs into `frontend/.env.local`:
+
+```env
+NEXT_PUBLIC_TREASURY_CONTRACT_ID=<treasury-id-from-deployed-contracts.json>
+NEXT_PUBLIC_GOVERNANCE_CONTRACT_ID=<governance-id>
+NEXT_PUBLIC_VAULT_CONTRACT_ID=<token_vault-id>
+NEXT_PUBLIC_ACL_CONTRACT_ID=<access_control-id>
+```
+
+### Automated Deployment via GitHub Actions
+
+Push a version tag to trigger the [deploy workflow](.github/workflows/deploy.yml):
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+The workflow installs the Stellar CLI, builds contracts, deploys to testnet, uploads `deployed-contracts.json` as a build artifact, and commits the updated file back to `main`.
+
+**Required secret:** `STELLAR_DEPLOY_SECRET_KEY` — set this in your repository's Settings → Secrets.
+
+---
+
 ## 📚 Documentation & Trackers
 
 We have separated our task lists for better organization. Please refer to the specific tracker for your area of contribution:

--- a/backend/src/governance/governance.controller.ts
+++ b/backend/src/governance/governance.controller.ts
@@ -6,6 +6,13 @@ import {
   NotFoundException,
   BadRequestException,
 } from "@nestjs/common";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+} from "@nestjs/swagger";
 import { Public } from "../decorators/public.decorator";
 import { z } from "zod";
 import { GovernanceService } from "./governance.service";
@@ -29,12 +36,20 @@ const paginationSchema = z.object({
   action: z.string().optional(),
 });
 
+@ApiTags("governance")
 @Controller("api/governance")
 @Public()
 export class GovernanceController {
   constructor(private readonly governanceService: GovernanceService) {}
 
   @Get("proposals")
+  @ApiOperation({ summary: "List governance proposals with pagination and filters" })
+  @ApiQuery({ name: "page", required: false, type: Number, description: "Page number (default: 1)" })
+  @ApiQuery({ name: "limit", required: false, type: Number, description: "Items per page (default: 10, max: 100)" })
+  @ApiQuery({ name: "status", required: false, type: String, description: "Filter by proposal status (e.g. open, passed, rejected)" })
+  @ApiQuery({ name: "action", required: false, type: String, description: "Filter by proposal action type" })
+  @ApiResponse({ status: 200, description: "Returns paginated list of proposals" })
+  @ApiResponse({ status: 400, description: "Invalid pagination parameters" })
   async getProposals(
     @Query("page") page?: string,
     @Query("limit") limit?: string,
@@ -58,6 +73,10 @@ export class GovernanceController {
   }
 
   @Get("proposals/:id")
+  @ApiOperation({ summary: "Get a proposal by ID" })
+  @ApiParam({ name: "id", description: "Proposal ID" })
+  @ApiResponse({ status: 200, description: "Returns proposal details" })
+  @ApiResponse({ status: 404, description: "Proposal not found" })
   async getProposal(@Param("id") id: string) {
     const proposal = await this.governanceService.getProposalById(id);
     if (!proposal) {
@@ -67,17 +86,24 @@ export class GovernanceController {
   }
 
   @Get("proposals/:id/votes")
+  @ApiOperation({ summary: "Get votes for a proposal" })
+  @ApiParam({ name: "id", description: "Proposal ID" })
+  @ApiResponse({ status: 200, description: "Returns list of votes for the proposal" })
   async getProposalVotes(@Param("id") id: string) {
     return this.governanceService.getProposalVotes(id);
   }
 
   @Get("members")
+  @ApiOperation({ summary: "Get governance members" })
+  @ApiResponse({ status: 200, description: "Returns list of governance members" })
   async getMembers() {
     const members = await this.governanceService.getMembers();
     return { members };
   }
 
   @Get("config")
+  @ApiOperation({ summary: "Get governance configuration" })
+  @ApiResponse({ status: 200, description: "Returns governance configuration including quorum, voting period, and member list" })
   async getConfig() {
     return this.governanceService.getConfig();
   }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { Logger } from '@nestjs/common';
+import { Logger, VersioningType } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { config } from './config';
 import 'reflect-metadata';
@@ -23,6 +23,13 @@ async function bootstrap() {
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     preflightContinue: false,
     optionsSuccessStatus: 204,
+  });
+
+  // Header-based API versioning — pass X-API-Version: 1 to target a specific version.
+  // Controllers without @Version() respond to all versions (version-neutral).
+  app.enableVersioning({
+    type: VersioningType.HEADER,
+    header: 'X-API-Version',
   });
 
   // Setup Swagger/OpenAPI documentation

--- a/backend/src/vault/vault.controller.ts
+++ b/backend/src/vault/vault.controller.ts
@@ -6,6 +6,13 @@ import {
   NotFoundException,
   BadRequestException,
 } from "@nestjs/common";
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiParam,
+} from "@nestjs/swagger";
 import { Public } from "../decorators/public.decorator";
 import { z } from "zod";
 import { VaultService } from "./vault.service";
@@ -27,12 +34,18 @@ const paginationSchema = z.object({
     ),
 });
 
+@ApiTags("vault")
 @Controller("api/vault")
 @Public()
 export class VaultController {
   constructor(private readonly vaultService: VaultService) {}
 
   @Get("locks")
+  @ApiOperation({ summary: "List token locks with pagination" })
+  @ApiQuery({ name: "page", required: false, type: Number, description: "Page number (default: 1)" })
+  @ApiQuery({ name: "limit", required: false, type: Number, description: "Items per page (default: 10, max: 100)" })
+  @ApiResponse({ status: 200, description: "Returns paginated list of token locks" })
+  @ApiResponse({ status: 400, description: "Invalid pagination parameters" })
   async getLocks(@Query("page") page?: string, @Query("limit") limit?: string) {
     const result = paginationSchema.safeParse({ page, limit });
     if (!result.success) {
@@ -46,6 +59,10 @@ export class VaultController {
   }
 
   @Get("locks/:id")
+  @ApiOperation({ summary: "Get a token lock by ID" })
+  @ApiParam({ name: "id", description: "Lock ID" })
+  @ApiResponse({ status: 200, description: "Returns lock details" })
+  @ApiResponse({ status: 404, description: "Lock not found" })
   async getLock(@Param("id") id: string) {
     const lock = await this.vaultService.getLockById(id);
     if (!lock) {
@@ -55,6 +72,11 @@ export class VaultController {
   }
 
   @Get("vestings")
+  @ApiOperation({ summary: "List vesting schedules with pagination" })
+  @ApiQuery({ name: "page", required: false, type: Number, description: "Page number (default: 1)" })
+  @ApiQuery({ name: "limit", required: false, type: Number, description: "Items per page (default: 10, max: 100)" })
+  @ApiResponse({ status: 200, description: "Returns paginated list of vesting schedules" })
+  @ApiResponse({ status: 400, description: "Invalid pagination parameters" })
   async getVestings(
     @Query("page") page?: string,
     @Query("limit") limit?: string,
@@ -71,6 +93,10 @@ export class VaultController {
   }
 
   @Get("vestings/:id")
+  @ApiOperation({ summary: "Get a vesting schedule by ID" })
+  @ApiParam({ name: "id", description: "Vesting schedule ID" })
+  @ApiResponse({ status: 200, description: "Returns vesting schedule details" })
+  @ApiResponse({ status: 404, description: "Vesting schedule not found" })
   async getVesting(@Param("id") id: string) {
     const vesting = await this.vaultService.getVestingById(id);
     if (!vesting) {
@@ -80,6 +106,8 @@ export class VaultController {
   }
 
   @Get("stats")
+  @ApiOperation({ summary: "Get vault statistics" })
+  @ApiResponse({ status: 200, description: "Returns vault statistics including total locked, total vested, and active schedules" })
   async getStats() {
     return this.vaultService.getStats();
   }

--- a/docs/FRONTEND_GUIDE.md
+++ b/docs/FRONTEND_GUIDE.md
@@ -9,9 +9,13 @@
 4. [Key Concepts](#key-concepts)
 5. [Wallet Integration](#wallet-integration)
 6. [Contract Interaction Pattern](#contract-interaction-pattern)
-7. [Components](#components)
-8. [Adding Features](#adding-features)
-9. [Architecture Decision Records](#architecture-decision-records)
+7. [SorobanClient Polling Strategy](#sorobanlient-polling-strategy)
+8. [Data Loading with Request Guards](#data-loading-with-request-guards)
+9. [Error Classification](#error-classification)
+10. [Components](#components)
+11. [Hook Usage](#hook-usage)
+12. [Adding Features](#adding-features)
+13. [Architecture Decision Records](#architecture-decision-records)
 
 ## Architecture Decision Records
 
@@ -301,19 +305,382 @@ export function TreasuryApprovalFlow({ txId }: { txId: number }) {
 
 ---
 
+## SorobanClient Polling Strategy
+
+`SorobanClient` (`src/lib/sorobanClient.ts`) is the shared RPC client. All hooks import the singleton `sorobanClient` so they share one consistent poll policy.
+
+### Poll Policy
+
+```ts
+// Default: 2 s interval × 30 attempts = ~60 s total timeout
+export const DEFAULT_POLL_POLICY: PollPolicy = {
+  intervalMs: 2_000,
+  maxAttempts: 30,
+};
+
+// Override per feature when faster or slower confirmation is needed:
+const fastClient = new SorobanClient(undefined, { intervalMs: 1_000, maxAttempts: 60 });
+```
+
+### Reading a Contract Value (Simulation Only — No Ledger Write)
+
+```ts
+import { sorobanClient } from "@/lib/sorobanClient";
+
+const balance = await sorobanClient.readValue(
+  contractId,            // "C…" strkey
+  "get_balance",         // contract function name
+  [],                    // XDR-encoded arguments
+  userAddress,           // simulation source account
+  signal,                // AbortSignal (optional, for cancellation)
+  (raw) => BigInt(raw),  // decoder (optional, transforms native JS value)
+);
+```
+
+### Sending a Signed Transaction and Polling for Confirmation
+
+```ts
+import { sorobanClient } from "@/lib/sorobanClient";
+
+// signedTx must be a fully-signed Transaction object
+const result = await sorobanClient.send(signedTx, {
+  intervalMs: 3_000,  // optional per-call policy override
+  maxAttempts: 20,
+});
+// result.status === "SUCCESS" on confirmation
+```
+
+### Resuming Polling from a Known Transaction Hash
+
+```ts
+// Useful after a page reload when the hash was stored externally
+const result = await sorobanClient.pollForResult(txHash);
+```
+
+---
+
+## Data Loading with Request Guards
+
+The `createLatestRequestGuard` function (`src/lib/requestGuard.ts`) prevents stale responses from overwriting newer state when async calls overlap (e.g., rapid navigation or rapid refreshes).
+
+### How It Works
+
+1. Each hook holds one `LatestRequestGuard` in a `useRef`.
+2. `guard.begin()` increments a monotonic ID and cancels the previous `AbortController`.
+3. After the async call, `guard.isCurrent(id)` confirms the response is still wanted.
+4. On unmount, `guard.dispose()` aborts any in-flight request and prevents future state updates.
+
+```ts
+import { createLatestRequestGuard, isAbortError } from "@/lib/requestGuard";
+import { useRef, useCallback, useEffect } from "react";
+
+function useContractData() {
+  const guardRef = useRef(createLatestRequestGuard());
+
+  const fetchData = useCallback(async () => {
+    // Cancels the previous request and returns a new { id, signal } pair
+    const { id, signal } = guardRef.current.begin();
+
+    try {
+      const data = await fetchFromChain(signal); // pass signal for mid-flight abort
+
+      // Guard: only write to state if this is still the latest call
+      if (guardRef.current.isCurrent(id)) {
+        setData(data);
+      }
+    } catch (err) {
+      if (isAbortError(err)) return; // superseded — ignore silently
+
+      if (guardRef.current.isCurrent(id)) {
+        setError(classifyError(err));
+      }
+    }
+  }, []);
+
+  // Abort on unmount to prevent setState on an unmounted component
+  useEffect(() => {
+    return () => guardRef.current.dispose();
+  }, []);
+}
+```
+
+### Visibility-Gated Background Polling
+
+All data hooks poll on a 30-second interval but pause when the browser tab is hidden to avoid unnecessary RPC calls:
+
+```ts
+import { usePageVisibility } from "@/hooks/usePageVisibility";
+
+const REFRESH_INTERVAL = 30_000;
+
+useEffect(() => {
+  refresh(); // immediate initial fetch
+
+  const interval = setInterval(() => {
+    if (isPageVisible) refresh(); // skip updates when tab is hidden
+  }, REFRESH_INTERVAL);
+
+  return () => {
+    clearInterval(interval);
+    guardRef.current.cancel("Component refresh cancelled.");
+  };
+}, [refresh, isPageVisible]);
+```
+
+---
+
+## Error Classification
+
+`classifyError` (`src/lib/errors.ts`) converts any thrown value into a structured `AppError`. Every hook uses it so the UI always receives a uniform, actionable error shape — no raw Error objects leak to components.
+
+### AppError Shape
+
+```ts
+interface AppError {
+  code: ErrorCode;      // machine-readable code for programmatic handling
+  message: string;      // human-readable text safe for display in the UI
+  recoverable: boolean; // true → user can retry; false → action cannot succeed
+  detail?: string;      // raw error string for debugging only, never display
+}
+```
+
+### Error Code Reference
+
+| Category | Code | Recoverable | Triggered by |
+|----------|------|-------------|--------------|
+| Wallet | `WALLET_NOT_INSTALLED` | No | Freighter extension not present |
+| Wallet | `WALLET_NOT_CONNECTED` | Yes | Wallet not yet connected |
+| Wallet | `WALLET_SIGN_REJECTED` | Yes | User declined the signature prompt |
+| Wallet | `WALLET_NETWORK_MISMATCH` | Yes | Freighter on wrong network |
+| RPC | `RPC_TIMEOUT` | Yes | `getTransaction` polling exceeded limit |
+| RPC | `RPC_SIMULATION_FAILED` | Yes | Preflight/simulate returned an error |
+| RPC | `RPC_SUBMISSION_FAILED` | Yes | `sendTransaction` returned ERROR |
+| Contract | `CONTRACT_UNAUTHORIZED` | No | Caller lacks the required on-chain role |
+| Contract | `CONTRACT_EXECUTION_FAILED` | Yes | General contract panic or revert |
+| Validation | `VALIDATION_INVALID_ADDRESS` | Yes | Invalid Stellar strkey format |
+| Validation | `VALIDATION_INVALID_AMOUNT` | Yes | Amount out of range or non-numeric |
+
+### Usage in Hooks
+
+```ts
+import { classifyError, isAbortError } from "@/lib/errors";
+
+try {
+  await vote(proposalId, voteFor);
+} catch (err: unknown) {
+  if (isAbortError(err)) return; // cancelled — no-op
+
+  if (guardRef.current.isCurrent(request.id)) {
+    setError(classifyError(err));
+    // e.g. { code: "WALLET_SIGN_REJECTED", message: "Transaction was rejected…", recoverable: true }
+  }
+}
+```
+
+### Displaying Structured Errors in Components
+
+```tsx
+import { ERROR_CODE_LABELS, type AppError } from "@/lib/errors";
+
+function ErrorBanner({ error, onRetry }: { error: AppError; onRetry?: () => void }) {
+  return (
+    <div role="alert" className="card p-4 border-red-500/30">
+      <strong>{ERROR_CODE_LABELS[error.code]}</strong>
+      <p className="text-sm text-gray-300 mt-1">{error.message}</p>
+      {error.recoverable && onRetry && (
+        <button className="btn-secondary mt-2 text-xs" onClick={onRetry}>
+          Try Again
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+---
+
 ## Components
 
 ### WalletConnect
 Smart button handling 4 states: Not Installed, Disconnected, Connecting, Connected.
 
+```tsx
+// Used in layout.tsx — reads wallet state from FreighterProvider context
+<WalletConnect />
+```
+
 ### TreasuryCard
-Displays a treasury transaction with approval progress and action button. Props: `txId`, `to`, `amount`, `memo`, `approvals`, `threshold`, `executed`.
+Displays a treasury transaction with approval progress and an Approve or Execute action button.
+
+```tsx
+import { TreasuryCard } from "@/components/TreasuryCard";
+
+<TreasuryCard
+  txId={1}
+  to="GABCDE..."
+  amount={BigInt(10_000_000)}       // stroops (1 XLM = 10_000_000 stroops)
+  memo="Q1 vendor payment"
+  approvals={["GABCDE...", "GXYZ..."]}
+  threshold={3}
+  executed={false}
+  isPendingApproval={false}
+  isPendingExecution={false}
+  currentAddress={address}
+  canSign={true}
+  onApprove={(txId) => approve(txId)}
+  onExecute={(txId) => execute(txId)}
+/>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `txId` | `number` | On-chain transaction ID |
+| `to` | `string` | Recipient Stellar address (full strkey) |
+| `amount` | `bigint` | Amount in stroops |
+| `memo` | `string` | Optional transaction memo |
+| `approvals` | `string[]` | Array of approver addresses already recorded on-chain |
+| `threshold` | `number` | Minimum approvals required to execute |
+| `executed` | `boolean` | Whether the transaction has been executed |
+| `isPendingApproval` | `boolean?` | Loading state while approve transaction is in-flight |
+| `isPendingExecution` | `boolean?` | Loading state while execute transaction is in-flight |
+| `currentAddress` | `string \| null` | Connected wallet address |
+| `canSign` | `boolean` | Whether the current user is an authorised signer |
+| `onApprove` | `(txId: number) => void` | Callback invoked when Approve is clicked |
+| `onExecute` | `(txId: number) => void` | Callback invoked when Execute is clicked |
 
 ### ProposalCard
-Links to proposal detail page. Shows status badge, vote progress bar, and proposer. Props: `id`, `title`, `description`, `status`, `votesFor`, `votesAgainst`, `totalMembers`, `proposer`.
+Links to proposal detail page. Shows status badge, vote progress bar, and proposer.
+
+```tsx
+import { ProposalCard } from "@/components/ProposalCard";
+
+<ProposalCard
+  id={5}
+  title="Fund Q2 Development"
+  description="Allocate 500 XLM for Q2 engineering work"
+  status="open"
+  votesFor={8}
+  votesAgainst={2}
+  totalMembers={15}
+  proposer="GABCDE..."
+/>
+```
 
 ### VoteButton
-Handles vote casting with disabled states. Props: `proposalId`, `voteFor`, `hasVoted`, `votingClosed`, `onVote`.
+Handles vote casting with disabled states for: already voted, voting closed, wallet disconnected, and pending on-chain confirmation.
+
+```tsx
+import { VoteButton } from "@/components/VoteButton";
+
+<VoteButton
+  proposalId={5}
+  voteFor={true}          // true → "Vote For", false → "Vote Against"
+  hasVoted={false}
+  votingClosed={false}
+  isPending={false}
+  onVoteSuccess={() => refetch()}
+/>
+```
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `proposalId` | `number` | Governance proposal ID |
+| `voteFor` | `boolean` | `true` renders "Vote For", `false` renders "Vote Against" |
+| `hasVoted` | `boolean` | Whether the connected wallet has already voted |
+| `votingClosed` | `boolean` | Whether the voting period has ended |
+| `isPending` | `boolean?` | Optional external pending override |
+| `onVoteSuccess` | `() => void \| Promise<void>` | Callback after a successful vote submission |
+
+---
+
+## Hook Usage
+
+### useTreasury
+
+Loads balance, config, and transactions. Provides deposit, propose, approve, and execute actions with optimistic updates.
+
+```tsx
+import { useTreasury } from "@/hooks/useTreasury";
+
+function TreasuryPage() {
+  const {
+    balance,           // bigint — treasury balance in stroops
+    config,            // TreasuryConfig | null — { signers, threshold, txCount, balance }
+    transactions,      // TreasuryTransaction[] — most recent 20 transactions
+    isLoading,         // boolean
+    error,             // AppError | null
+    isNetworkMismatch, // boolean — Freighter vs app network mismatch
+    pendingActions,    // ReadonlyMap<number, "approve" | "execute"> — in-flight tx IDs
+    approve,           // (txId: number) => Promise<void>
+    execute,           // (txId: number) => Promise<void>
+    deposit,           // (amount: bigint | number) => Promise<void>
+    proposeWithdrawal, // (to: string, amount: bigint | number, memo: string) => Promise<void>
+    refresh,           // () => Promise<void>
+    clearError,        // () => void
+  } = useTreasury();
+
+  return (
+    <>
+      <p>Balance: {Number(balance) / 10_000_000} XLM</p>
+      {transactions.map((tx) => (
+        <TreasuryCard
+          key={tx.id}
+          {...tx}
+          currentAddress={address ?? null}
+          canSign={config?.signers.includes(address ?? "") ?? false}
+          isPendingApproval={pendingActions.get(tx.id) === "approve"}
+          isPendingExecution={pendingActions.get(tx.id) === "execute"}
+          onApprove={approve}
+          onExecute={execute}
+        />
+      ))}
+    </>
+  );
+}
+```
+
+### useGovernance
+
+Loads governance config and provides proposal CRUD, voting, finalisation, and execution. Tracks optimistic pending votes before chain confirmation.
+
+```tsx
+import { useGovernance } from "@/hooks/useGovernance";
+
+function ProposalDetailPage({ proposalId }: { proposalId: number }) {
+  const {
+    config,           // GovernanceConfig | null — { members, quorum, votingPeriod, proposals }
+    isLoading,        // boolean
+    error,            // AppError | null
+    pendingVotes,     // ReadonlyMap<number, boolean> — optimistic vote tracking
+    getProposal,      // (id: number) => Promise<GovernanceProposal>
+    createProposal,   // (title, description, action, amount, target) => Promise<void>
+    vote,             // (proposalId: number, voteFor: boolean) => Promise<void>
+    finalize,         // (proposalId: number) => Promise<void>
+    executeProposal,  // (proposalId: number) => Promise<void>
+    hasVoted,         // (proposalId: number) => Promise<boolean>
+    refresh,          // () => Promise<void>
+  } = useGovernance();
+
+  return (
+    <div className="flex gap-2">
+      <VoteButton
+        proposalId={proposalId}
+        voteFor={true}
+        hasVoted={pendingVotes.has(proposalId)}
+        votingClosed={false}
+        onVoteSuccess={refresh}
+      />
+      <VoteButton
+        proposalId={proposalId}
+        voteFor={false}
+        hasVoted={pendingVotes.has(proposalId)}
+        votingClosed={false}
+        onVoteSuccess={refresh}
+      />
+    </div>
+  );
+}
+```
 
 ---
 

--- a/frontend/src/components/TreasuryCard.tsx
+++ b/frontend/src/components/TreasuryCard.tsx
@@ -39,8 +39,31 @@ export const TreasuryCard: React.FC<TreasuryCardProps> = ({
       (addr) => addr.toLowerCase() === currentAddress.toLowerCase(),
     );
 
+  const approveDescId = `approve-desc-${txId}`;
+  const executeDescId = `execute-desc-${txId}`;
+
+  const approveDisabledReason = hasApproved
+    ? "You have already approved this transaction."
+    : !canSign
+      ? "You do not have signing permission for this treasury."
+      : isPendingApproval
+        ? "Approval is being confirmed on chain."
+        : undefined;
+
+  const executeDisabledReason = !canSign
+    ? "You do not have signing permission for this treasury."
+    : isPendingExecution
+      ? "Execution is being confirmed on chain."
+      : undefined;
+
   return (
     <div className="card p-5 group hover:border-primary-500/50 transition-colors">
+      {/* Live region announces pending action state changes to screen readers */}
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {isPendingApproval && "Approval transaction pending confirmation."}
+        {isPendingExecution && "Execution transaction pending confirmation."}
+      </div>
+
       <div className="flex justify-between items-start mb-4">
         <div>
           <h3 className="font-bold text-lg text-white">Transaction #{txId}</h3>
@@ -81,12 +104,21 @@ export const TreasuryCard: React.FC<TreasuryCardProps> = ({
       </div>
 
       <div className="pt-4 border-t border-stellar-border flex items-center justify-between">
-        <div className="flex flex-col gap-1">
+        {/* role="status" + aria-live announces approval count changes to screen readers */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label={`${approvals.length} of ${threshold} approvals required${isReadyToExecute ? ", threshold met" : ""}`}
+          className="flex flex-col gap-1"
+        >
           <span className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
             Approvals
           </span>
           <div className="flex items-center gap-1.5">
-            <div className="h-1.5 w-24 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              aria-hidden="true"
+              className="h-1.5 w-24 bg-gray-800 rounded-full overflow-hidden"
+            >
               <div
                 className={`h-full transition-all duration-500 ${isReadyToExecute ? "bg-green-500" : "bg-primary-500"
                   }`}
@@ -95,7 +127,7 @@ export const TreasuryCard: React.FC<TreasuryCardProps> = ({
                 }}
               />
             </div>
-            <span className="text-xs font-medium text-gray-300">
+            <span aria-hidden="true" className="text-xs font-medium text-gray-300">
               {approvals.length} / {threshold}
             </span>
           </div>
@@ -105,34 +137,56 @@ export const TreasuryCard: React.FC<TreasuryCardProps> = ({
           {!executed && (
             <>
               {isReadyToExecute ? (
-                <button
-                  className="btn-primary py-1.5 px-4 text-xs"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onExecute?.(txId);
-                  }}
-                  disabled={!canSign || isPendingExecution}
-                >
-                  {isPendingExecution ? "Executing..." : "Execute"}
-                </button>
+                <>
+                  {executeDisabledReason && (
+                    <span id={executeDescId} className="sr-only">
+                      {executeDisabledReason}
+                    </span>
+                  )}
+                  <button
+                    aria-label={`Execute transaction #${txId}`}
+                    aria-describedby={executeDisabledReason ? executeDescId : undefined}
+                    className="btn-primary py-1.5 px-4 text-xs focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onExecute?.(txId);
+                    }}
+                    disabled={!canSign || isPendingExecution}
+                  >
+                    {isPendingExecution ? "Executing..." : "Execute"}
+                  </button>
+                </>
               ) : (
-                <button
-                  className={`py-1.5 px-4 text-xs rounded-lg font-medium transition-all ${hasApproved || !canSign
-                      ? "bg-gray-800 text-gray-500 cursor-not-allowed"
-                      : "bg-white/10 text-white hover:bg-white/20 border border-white/10"
-                    }`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!hasApproved && canSign) onApprove?.(txId);
-                  }}
-                  disabled={hasApproved || !canSign || isPendingApproval}
-                >
-                  {isPendingApproval
-                    ? "Approving..."
-                    : hasApproved
-                      ? "Approved"
-                      : "Approve"}
-                </button>
+                <>
+                  {approveDisabledReason && (
+                    <span id={approveDescId} className="sr-only">
+                      {approveDisabledReason}
+                    </span>
+                  )}
+                  <button
+                    aria-label={
+                      hasApproved
+                        ? `Already approved transaction #${txId}`
+                        : `Approve transaction #${txId}`
+                    }
+                    aria-describedby={approveDisabledReason ? approveDescId : undefined}
+                    className={`py-1.5 px-4 text-xs rounded-lg font-medium transition-all focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900 ${hasApproved || !canSign
+                        ? "bg-gray-800 text-gray-500 cursor-not-allowed"
+                        : "bg-white/10 text-white hover:bg-white/20 border border-white/10"
+                      }`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!hasApproved && canSign) onApprove?.(txId);
+                    }}
+                    disabled={hasApproved || !canSign || isPendingApproval}
+                  >
+                    {isPendingApproval
+                      ? "Approving..."
+                      : hasApproved
+                        ? "Approved"
+                        : "Approve"}
+                  </button>
+                </>
               )}
             </>
           )}

--- a/frontend/src/components/VoteButton.tsx
+++ b/frontend/src/components/VoteButton.tsx
@@ -49,7 +49,7 @@ export const VoteButton: React.FC<VoteButtonProps> = ({
     }
   };
 
-  const title = hasVoted
+  const disabledReason = hasVoted
     ? "You have already voted on this proposal"
     : votingClosed
       ? "Voting is closed"
@@ -59,19 +59,33 @@ export const VoteButton: React.FC<VoteButtonProps> = ({
           ? "Waiting for vote confirmation"
           : "";
 
+  const baseLabel = voteFor ? "Vote For" : "Vote Against";
+  const ariaLabel = disabledReason
+    ? `${baseLabel}: ${disabledReason}`
+    : baseLabel;
+  const descId = `vote-desc-${proposalId}-${voteFor ? "for" : "against"}`;
+
   return (
-    <button
-      className={voteFor ? "btn-primary" : "btn-secondary"}
-      disabled={isDisabled}
-      onClick={handleVote}
-      title={title}
-      type="button"
-    >
-      {isThisVotePending
-        ? "Submitting..."
-        : voteFor
-          ? "Vote For"
-          : "Vote Against"}
-    </button>
+    <>
+      {isDisabled && disabledReason && (
+        <span id={descId} className="sr-only">
+          {disabledReason}
+        </span>
+      )}
+      <button
+        aria-label={ariaLabel}
+        aria-describedby={isDisabled && disabledReason ? descId : undefined}
+        className={`${voteFor ? "btn-primary" : "btn-secondary"} focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900`}
+        disabled={isDisabled}
+        onClick={handleVote}
+        type="button"
+      >
+        {isThisVotePending
+          ? "Submitting..."
+          : voteFor
+            ? "Vote For"
+            : "Vote Against"}
+      </button>
+    </>
   );
 };

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Deploy StellarGuard Soroban contracts to Stellar testnet or mainnet.
+#
+# Usage:
+#   ./scripts/deploy.sh [--network testnet|mainnet] [--source <identity-or-secret>]
+#
+# Environment variables (alternative to flags):
+#   DEPLOY_NETWORK  — testnet (default) or mainnet
+#   DEPLOY_SOURCE   — Stellar CLI identity name or secret key
+#
+# Prerequisites:
+#   - stellar CLI  (cargo install --locked stellar-cli)
+#   - cargo + wasm32-unknown-unknown target
+
+set -euo pipefail
+
+NETWORK="${DEPLOY_NETWORK:-testnet}"
+SOURCE="${DEPLOY_SOURCE:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+CONTRACTS_DIR="$ROOT_DIR/smartcontract"
+OUTPUT_FILE="$SCRIPT_DIR/deployed-contracts.json"
+
+# ── Color helpers ─────────────────────────────────────────────────────────────
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log()   { echo -e "${GREEN}[deploy]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[warn]${NC}   $*"; }
+error() { echo -e "${RED}[error]${NC}  $*" >&2; exit 1; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --network) NETWORK="$2"; shift 2 ;;
+    --source)  SOURCE="$2";  shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 [--network testnet|mainnet] [--source <identity>]"
+      exit 0
+      ;;
+    *) error "Unknown argument: $1" ;;
+  esac
+done
+
+# ── Validation ────────────────────────────────────────────────────────────────
+[[ "$NETWORK" == "testnet" || "$NETWORK" == "mainnet" ]] \
+  || error "Network must be 'testnet' or 'mainnet', got: $NETWORK"
+
+command -v stellar &>/dev/null \
+  || error "stellar CLI not found. Install: cargo install --locked stellar-cli"
+
+command -v cargo &>/dev/null \
+  || error "cargo not found. Install Rust: https://rustup.rs"
+
+if [[ -z "$SOURCE" ]]; then
+  warn "DEPLOY_SOURCE not set — using 'default' Stellar CLI identity."
+  warn "Pass --source <name-or-secret> or set DEPLOY_SOURCE to override."
+  SOURCE="default"
+fi
+
+if [[ "$NETWORK" == "mainnet" ]]; then
+  warn "Deploying to MAINNET. Real XLM will be spent. Press Ctrl-C within 5s to abort."
+  sleep 5
+fi
+
+log "Network : $NETWORK"
+log "Source  : $SOURCE"
+log ""
+
+# ── Step 1: Build optimised WASM ──────────────────────────────────────────────
+log "Building contracts (release profile)..."
+(cd "$CONTRACTS_DIR" && stellar contract build)
+log "Build complete."
+log ""
+
+# Contract name → WASM filename (derived from Cargo package names with hyphens → underscores)
+declare -A WASM_PATHS=(
+  [treasury]="$CONTRACTS_DIR/target/wasm32-unknown-unknown/release/stellar_guard_treasury.wasm"
+  [governance]="$CONTRACTS_DIR/target/wasm32-unknown-unknown/release/stellar_guard_governance.wasm"
+  [token_vault]="$CONTRACTS_DIR/target/wasm32-unknown-unknown/release/stellar_guard_token_vault.wasm"
+  [access_control]="$CONTRACTS_DIR/target/wasm32-unknown-unknown/release/stellar_guard_access_control.wasm"
+)
+
+# ── Step 2: Deploy each contract ──────────────────────────────────────────────
+declare -A DEPLOYED_IDS=()
+
+for name in treasury governance token_vault access_control; do
+  wasm="${WASM_PATHS[$name]}"
+
+  if [[ ! -f "$wasm" ]]; then
+    warn "WASM not found for '$name' at $wasm — skipping."
+    DEPLOYED_IDS[$name]=""
+    continue
+  fi
+
+  log "Deploying $name..."
+  contract_id=$(
+    stellar contract deploy \
+      --wasm "$wasm" \
+      --source "$SOURCE" \
+      --network "$NETWORK" \
+      2>&1 | tail -1
+  )
+
+  log "  $name → $contract_id"
+  DEPLOYED_IDS[$name]="$contract_id"
+done
+
+# ── Step 3: Write deployed-contracts.json ─────────────────────────────────────
+log ""
+log "Writing $OUTPUT_FILE..."
+
+cat > "$OUTPUT_FILE" <<JSON
+{
+  "network": "$NETWORK",
+  "deployedAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "contracts": {
+    "treasury":       "${DEPLOYED_IDS[treasury]:-}",
+    "governance":     "${DEPLOYED_IDS[governance]:-}",
+    "token_vault":    "${DEPLOYED_IDS[token_vault]:-}",
+    "access_control": "${DEPLOYED_IDS[access_control]:-}"
+  }
+}
+JSON
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+log ""
+log "Deployment complete. Contract IDs:"
+printf "  %-20s %s\n" "treasury"       "${DEPLOYED_IDS[treasury]:-"(skipped)"}"
+printf "  %-20s %s\n" "governance"     "${DEPLOYED_IDS[governance]:-"(skipped)"}"
+printf "  %-20s %s\n" "token_vault"    "${DEPLOYED_IDS[token_vault]:-"(skipped)"}"
+printf "  %-20s %s\n" "access_control" "${DEPLOYED_IDS[access_control]:-"(skipped)"}"
+log ""
+log "Contract IDs saved to $OUTPUT_FILE"
+log "Copy them into your frontend .env.local as NEXT_PUBLIC_*_CONTRACT_ID."

--- a/scripts/deployed-contracts.json
+++ b/scripts/deployed-contracts.json
@@ -1,0 +1,10 @@
+{
+  "network": "",
+  "deployedAt": "",
+  "contracts": {
+    "treasury": "",
+    "governance": "",
+    "token_vault": "",
+    "access_control": ""
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #220, resolves #228, resolves #224, resolves #219

This PR addresses four open issues across documentation, accessibility, API docs, and DevOps.

---

### [DOC-1] Frontend guide — real interaction examples (#220)

`docs/FRONTEND_GUIDE.md` expanded with five new sections drawn directly from the codebase:

* **SorobanClient Polling Strategy** — `readValue`, `send`, `pollForResult` examples with the poll
  policy (`intervalMs` / `maxAttempts`)
* **Data Loading with Request Guards** — full `createLatestRequestGuard` pattern showing
  `begin()`, `isCurrent()`, `dispose()`, and the 30-second visibility-gated polling loop
* **Error Classification** — `AppError` shape, full error-code reference table, hook usage, and
  component `ErrorBanner` example
* **Components** — expanded with real TypeScript prop tables for `TreasuryCard` and `VoteButton`
* **Hook Usage** — `useTreasury` and `useGovernance` usage examples showing data flow from hook to
  component

Updated table of contents to reflect all new sections.

---

### [A11Y-3] VoteButton and TreasuryCard — missing ARIA states (#228)

**`VoteButton.tsx`**

* Added dynamic `aria-label` that reflects the current disabled reason (already voted / voting
  closed / wallet not connected / pending confirmation)
* Added `aria-describedby` pointing to a visually-hidden `<span>` with the full disabled
  explanation
* Added `focus-visible:ring-2` keyboard focus indicator classes

**`TreasuryCard.tsx`**

* Added `aria-live="polite" aria-atomic="true"` live region announcing pending approval/execution
  state changes to screen readers
* Wrapped approval count in `role="status" aria-live="polite"` with descriptive `aria-label` (`N  
  of M approvals required`)
* Added `aria-hidden="true"` to the decorative progress bar and count span (already announced by
  the status div)
* Added `aria-label` and `aria-describedby` to Approve and Execute buttons with reason text in
  visually-hidden spans
* Added `focus-visible:ring-2` keyboard focus indicator classes to all interactive buttons

---

### [DOC-5] Backend API Swagger documentation (#224)

* `@nestjs/swagger` was already installed; Swagger UI was already configured in `main.ts` at
  `/api/docs`
* **`governance.controller.ts`** — added `@ApiTags`, `@ApiOperation`, `@ApiResponse`, `@ApiQuery`,
  `@ApiParam` to all five endpoints
* **`vault.controller.ts`** — added `@ApiTags`, `@ApiOperation`, `@ApiResponse`, `@ApiQuery`,
  `@ApiParam` to all five endpoints
* **`main.ts`** — added header-based API versioning (`X-API-Version` header,
  `VersioningType.HEADER`); existing routes remain unchanged as all controllers are version-neutral

---

### [DO-16] Contract deployment scripts (#219)

* **`scripts/deploy.sh`** — bash script that builds release WASMs via `stellar contract build`,
  deploys all four contracts (`treasury`, `governance`, `token_vault`, `access_control`), and writes
  contract IDs to `scripts/deployed-contracts.json`
* **`scripts/deployed-contracts.json`** — template file committed to track deployed contract IDs
  per network
* **`.github/workflows/deploy.yml`** — GitHub Actions workflow triggered on `v*.*.*` tag push;
  installs Stellar CLI, configures deployer identity from `STELLAR_DEPLOY_SECRET_KEY` secret, runs
  the deploy script, uploads the JSON as a build artifact, and commits the updated file back to
  `main`
* **`README.md`** — added "Deploying Contracts" section documenting manual deploy, env var copy
  step, and the CI trigger flow

---

## Test plan

* [ ] Read `docs/FRONTEND_GUIDE.md` end-to-end — confirm all five new sections render correctly
  and code blocks are valid TypeScript
* [ ] Use a screen reader (VoiceOver / NVDA) on `VoteButton` in disabled states — confirm reason
  is announced
* [ ] Tab to Approve/Execute buttons in `TreasuryCard` — confirm focus ring is visible and reason
  is announced when disabled
* [ ] Start the backend (`npm run start:api`) and visit `http://localhost:3001/api/docs` — confirm
  governance and vault endpoints appear with full descriptions
* [ ] Run `./scripts/deploy.sh --help` — confirm script exits cleanly and prints usage
* [ ] Push a `v*.*.*` tag to a fork — confirm deploy workflow triggers and produces the artifact
