### PR TITLE
fix: resolve RQ-2, RQ-3, RQ-8, and PERF-1 code quality and performance issues

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,6 +2,8 @@
 # Copy this file to .env.local and update with your values
 
 # Stellar Configuration
+# Set NEXT_PUBLIC_NETWORK to "testnet", "futurenet", or "mainnet" (defaults to testnet)
+NEXT_PUBLIC_NETWORK=testnet
 NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
+import { SecureExternalLink } from "@/components/SecureExternalLink";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import { Toaster } from "react-hot-toast";
 import "./globals.css";
@@ -106,9 +107,9 @@ export default function RootLayout({
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row justify-between items-center opacity-50 text-sm">
               <p>© 2026 StellarGuard. Built on Stellar Soroban.</p>
               <div className="flex space-x-8 mt-4 md:mt-0">
-                <a href="#" className="hover:text-white transition-colors">Documentation</a>
-                <a href="#" className="hover:text-white transition-colors">Github</a>
-                <a href="#" className="hover:text-white transition-colors">Support</a>
+                <SecureExternalLink href="https://github.com/xqcxx/stellarguard#readme" className="hover:text-white transition-colors">Documentation</SecureExternalLink>
+                <SecureExternalLink href="https://github.com/xqcxx/stellarguard" className="hover:text-white transition-colors">Github</SecureExternalLink>
+                <SecureExternalLink href="https://github.com/xqcxx/stellarguard/discussions" className="hover:text-white transition-colors">Support</SecureExternalLink>
               </div>
             </div>
           </footer>

--- a/frontend/src/hooks/useTxLifecycle.ts
+++ b/frontend/src/hooks/useTxLifecycle.ts
@@ -98,12 +98,9 @@ export function useTxLifecycle() {
           const built = await steps.build();
 
           setStage("signing");
-          // signing and submitting are sequential but happen inside signAndSubmit;
-          // we advance to "submitting" immediately after the sign call resolves so
-          // the UI shows deterministic progress.
-          setStage("submitting");
           const result = await steps.sign(built);
-
+          // signing stage persists while the wallet popup is open; only advance
+          // to confirming once the signed transaction has been submitted.
           setStage("confirming");
 
           if (runIdRef.current === runId) {

--- a/frontend/src/lib/network.ts
+++ b/frontend/src/lib/network.ts
@@ -36,14 +36,23 @@ export const NETWORKS = {
 // Active Network
 // ============================================================================
 
-/** The currently active network. Change this for deployment. */
-export const ACTIVE_NETWORK = NETWORKS.testnet;
+function resolveActiveNetwork(): (typeof NETWORKS)[keyof typeof NETWORKS] {
+  const key = (
+    process.env.NEXT_PUBLIC_NETWORK ?? "testnet"
+  ).toLowerCase() as keyof typeof NETWORKS;
+  return key in NETWORKS ? NETWORKS[key] : NETWORKS.testnet;
+}
 
-/** Soroban RPC URL for the active network. */
-export const SOROBAN_RPC_URL = ACTIVE_NETWORK.sorobanRpcUrl;
+/** The currently active network, resolved from NEXT_PUBLIC_NETWORK (defaults to testnet). */
+export const ACTIVE_NETWORK = resolveActiveNetwork();
 
-/** Horizon API URL for the active network. */
-export const HORIZON_URL = ACTIVE_NETWORK.horizonUrl;
+/** Soroban RPC URL — overridable via NEXT_PUBLIC_SOROBAN_RPC_URL. */
+export const SOROBAN_RPC_URL =
+  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ?? ACTIVE_NETWORK.sorobanRpcUrl;
+
+/** Horizon API URL — overridable via NEXT_PUBLIC_HORIZON_URL. */
+export const HORIZON_URL =
+  process.env.NEXT_PUBLIC_HORIZON_URL ?? ACTIVE_NETWORK.horizonUrl;
 
 /** Network passphrase for the active network. */
 export const NETWORK_PASSPHRASE = ACTIVE_NETWORK.networkPassphrase;
@@ -55,11 +64,14 @@ export const ACTIVE_NETWORK_KEY = Object.entries(NETWORKS).find(
 // Helpers
 // ============================================================================
 
-/**
- * Get a Soroban RPC server instance.
- */
+let _serverInstance: SorobanRpc.Server | null = null;
+
+/** Returns the shared Soroban RPC server singleton. Prefer sorobanClient in new code. */
 export function getServer(): SorobanRpc.Server {
-  return new SorobanRpc.Server(SOROBAN_RPC_URL);
+  if (!_serverInstance) {
+    _serverInstance = new SorobanRpc.Server(SOROBAN_RPC_URL);
+  }
+  return _serverInstance;
 }
 
 /**

--- a/frontend/src/lib/soroban.ts
+++ b/frontend/src/lib/soroban.ts
@@ -19,7 +19,7 @@ import { signTransaction } from "@stellar/freighter-api";
 import type { Decoder, GovernanceProposalAction } from "./contractData";
 import { readPublicEnv, requirePublicEnv } from "./env";
 import { throwIfAborted } from "./requestGuard";
-import { SOROBAN_RPC_URL, NETWORK_PASSPHRASE } from "./network";
+import { NETWORK_PASSPHRASE } from "./network";
 import { sorobanClient } from "./sorobanClient";
 
 // ============================================================================
@@ -35,12 +35,6 @@ export const CONTRACT_IDS = {
 
 const READONLY_SIMULATION_ACCOUNT_ENV =
   "NEXT_PUBLIC_SOROBAN_SIMULATION_ACCOUNT";
-
-// ============================================================================
-// Server Instance (kept for backward-compat; prefer sorobanClient in new code)
-// ============================================================================
-
-const server = new SorobanRpc.Server(SOROBAN_RPC_URL);
 
 const GOVERNANCE_ACTIONS: readonly GovernanceProposalAction[] = [
   "Funding",


### PR DESCRIPTION
## Summary

- **RQ-2** — `useTxLifecycle` signing stage was immediately overwritten by `submitting` before the wallet popup resolved; user never saw the signing state. Removed the premature `setStage("submitting")` so the signing stage persists while Freighter is open.
- **RQ-3** — `network.ts` hardcoded `NETWORKS.testnet` as the active network. Active network is now read from `NEXT_PUBLIC_NETWORK` (defaults to `testnet`); `NEXT_PUBLIC_SOROBAN_RPC_URL` and `NEXT_PUBLIC_HORIZON_URL` remain individually overridable. `.env.example` updated with the new variable.
- **RQ-8** — Footer links in `layout.tsx` used placeholder `href="#"`. Replaced with real URLs (documentation → repo README, GitHub → repo, Support → GitHub Discussions) using the existing `SecureExternalLink` component for proper `rel="noopener noreferrer"`.
- **PERF-1** — `getServer()` in `network.ts` created a new `SorobanRpc.Server` on every call. Now returns a cached module-level singleton. Removed the unused `server` instance from `soroban.ts` (all paths already route through the `sorobanClient` singleton).

## Files changed

- `frontend/src/hooks/useTxLifecycle.ts`
- `frontend/src/lib/network.ts`
- `frontend/src/lib/soroban.ts`
- `frontend/src/app/layout.tsx`
- `frontend/.env.example`

Closes #232 
Closes #236 
Closes #231 
Closes #237