### PR TITLE
fix: DB pool limits, SDK alignment, proposal bigint types, and analytics wiring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,16 @@ Thank you for your interest in building trustless treasury management on Stellar
 - **Backend:** FastAPI or NestJS
 - **Indexing:** Custom Soroban-RPC event listener
 
+## 📦 Required SDK Version
+
+Both the `frontend` and `backend` packages must use the **same** `@stellar/stellar-sdk` version.
+The required version is **`^12.3.0`** (currently `12.3.0`).
+
+> Keeping both packages on the same minor range ensures XDR encoding and event
+> parsing are consistent between the frontend transaction builders and the
+> backend event indexer. Always update both `package.json` files together and
+> verify event parsing when bumping the SDK.
+
 ## 📝 Commit Guidelines (Strict)
 
 We follow a strict **Modular Commit** philosophy to ensure history is readable and revertible.

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -11,6 +11,7 @@ export interface Config {
   pollIntervalMs: number;
   corsOrigin: string | string[];
   nodeEnv: string;
+  dbPoolMax: number;
 }
 
 function getContractIds(): string[] {
@@ -59,6 +60,7 @@ export function loadConfig(): Config {
   const networkPassphrase =
     process.env.NETWORK_PASSPHRASE || "Test SDF Network ; September 2015";
   const pollIntervalMs = parseInt(process.env.POLL_INTERVAL_MS || "5000", 10);
+  const dbPoolMax = parseInt(process.env.DB_POOL_MAX || "10", 10);
   const contractIds = getContractIds();
   const corsOrigin = parseCorsOrigin(nodeEnv);
 
@@ -86,6 +88,7 @@ export function loadConfig(): Config {
     pollIntervalMs,
     corsOrigin,
     nodeEnv,
+    dbPoolMax,
   };
 }
 

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -3,6 +3,13 @@ import { config } from "./config";
 
 export const pool = new Pool({
   connectionString: config.databaseUrl,
+  max: config.dbPoolMax,
+  idleTimeoutMillis: 30_000,
+  connectionTimeoutMillis: 5_000,
+});
+
+pool.on("error", (err) => {
+  console.error("Unexpected idle client error", err);
 });
 
 const SCHEMA_SQL = `

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@stellar/freighter-api": "^2.0.0",
-        "@stellar/stellar-sdk": "^11.3.0",
+        "@stellar/stellar-sdk": "^12.3.0",
         "clsx": "^2.1.1",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.9.0",
@@ -959,9 +959,8 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -1356,12 +1355,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-11.0.1.tgz",
-      "integrity": "sha512-VQh+1KEtFjegD6spx08+lENt8tQOkQQQZoLtqExjpRXyWlqDhEe+bXMlBTYKDc5MIynHyD42RPEib27UG17trA==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
+      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/js-xdr": "^3.1.1",
+        "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
         "bignumber.js": "^9.1.2",
         "buffer": "^6.0.3",
@@ -1369,17 +1368,17 @@
         "tweetnacl": "^1.0.3"
       },
       "optionalDependencies": {
-        "sodium-native": "^4.0.10"
+        "sodium-native": "^4.1.1"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-11.3.0.tgz",
-      "integrity": "sha512-i+heopibJNRA7iM8rEPz0AXphBPYvy2HDo8rxbDwWpozwCfw8kglP9cLkkhgJe8YicgLrdExz/iQZaLpqLC+6w==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
+      "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^11.0.1",
-        "axios": "^1.6.8",
+        "@stellar/stellar-base": "^12.1.1",
+        "axios": "^1.7.7",
         "bignumber.js": "^9.1.2",
         "eventsource": "^2.0.2",
         "randombytes": "^2.1.0",
@@ -1452,7 +1451,6 @@
       "integrity": "sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1470,7 +1468,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2030,7 +2027,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2462,9 +2458,9 @@
       }
     },
     "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
-      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
+      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -2480,9 +2476,9 @@
       }
     },
     "node_modules/bare-semver": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.2.tgz",
-      "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.3.tgz",
+      "integrity": "sha512-HS/A30bi2+PiRJfU6R4+Kp+6KeLSCSByjYM2iiobOKzLAvtu1CT+S8xWfiU7wz0erknjkUoC+yXy108tzIuP5Q==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -2594,7 +2590,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2919,8 +2914,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3400,7 +3394,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3569,7 +3562,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5057,7 +5049,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5895,7 +5886,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -5914,7 +5905,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -5967,7 +5958,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6184,7 +6174,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6197,7 +6186,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7274,7 +7262,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7522,7 +7509,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7652,7 +7638,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7728,38 +7713,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@stellar/freighter-api": "^2.0.0",
-    "@stellar/stellar-sdk": "^11.3.0",
+    "@stellar/stellar-sdk": "^12.3.0",
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.9.0",

--- a/frontend/src/app/governance/page.tsx
+++ b/frontend/src/app/governance/page.tsx
@@ -127,7 +127,7 @@ export default function GovernancePage() {
         data.title,
         data.description,
         data.action,
-        Number(data.amount),
+        data.amount,
         data.target,
       );
       const cfg = await getConfig();

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,6 +15,7 @@ const DiagnosticsPanel = dynamic(() => import("@/components/DiagnosticsPanel").t
 import { ToastContainer } from "@/components/Toast";
 import { NetworkMismatchBanner } from "@/components/NetworkMismatchBanner";
 import { MobileNav } from "@/components/MobileNav";
+import { RouteTracker } from "@/components/RouteTracker";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -70,6 +71,7 @@ export default function RootLayout({
     >
       <body className="min-h-screen bg-stellar-darker font-sans text-gray-100 selection:bg-stellar-blue/30">
         <FreighterProvider>
+          <RouteTracker />
           <nav className="border-b border-white/5 bg-stellar-darker/60 backdrop-blur-xl sticky top-0 z-50">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
               <div className="flex justify-between h-20 items-center">

--- a/frontend/src/components/RouteTracker.tsx
+++ b/frontend/src/components/RouteTracker.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { trackEvent } from "@/lib/analytics";
+
+export function RouteTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    trackEvent({ name: "page_view", properties: { path: pathname } });
+  }, [pathname]);
+
+  return null;
+}

--- a/frontend/src/components/VoteButton.tsx
+++ b/frontend/src/components/VoteButton.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { toast } from "react-hot-toast";
 import { useFreighter } from "@/hooks/useFreighter";
 import { useGovernance } from "@/hooks/useGovernance";
+import { trackEvent } from "@/lib/analytics";
 
 interface VoteButtonProps {
   proposalId: number;
@@ -37,6 +38,10 @@ export const VoteButton: React.FC<VoteButtonProps> = ({
 
     try {
       await vote(proposalId, voteFor);
+      trackEvent({
+        name: "proposal_vote",
+        properties: { proposalId: String(proposalId), vote: voteFor ? "for" : "against" },
+      });
       toast.success(
         `Vote submitted ${voteFor ? "for" : "against"} proposal #${proposalId}`,
       );

--- a/frontend/src/context/FreighterProvider.tsx
+++ b/frontend/src/context/FreighterProvider.tsx
@@ -8,6 +8,7 @@ import {
   getNetwork,
 } from "@stellar/freighter-api";
 import { classifyError, AppError, isAppError } from "@/lib/errors";
+import { trackEvent, truncateAddress } from "@/lib/analytics";
 
 export interface FreighterContextType {
   address: string | null;
@@ -74,6 +75,10 @@ export const FreighterProvider: React.FC<{ children: React.ReactNode }> = ({ chi
         setAddress(publicKey);
         const currentNetwork = await getNetwork();
         setNetwork(currentNetwork);
+        trackEvent({
+          name: "wallet_connect",
+          properties: { chain: "stellar", truncatedAddress: truncateAddress(publicKey) },
+        });
       } else {
         setError("User denied access");
       }
@@ -89,6 +94,7 @@ export const FreighterProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     setAddress(null);
     setNetwork(null);
     setError(null);
+    trackEvent({ name: "wallet_disconnect", properties: {} });
   };
 
   const value = {

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -57,6 +57,20 @@ export function useAnalytics() {
     [track],
   );
 
+  const trackProposalVote = useCallback(
+    (proposalId: string, vote: string) => {
+      track({ name: "proposal_vote", properties: { proposalId, vote } });
+    },
+    [track],
+  );
+
+  const trackTreasuryDeposit = useCallback(
+    (chain: string) => {
+      track({ name: "treasury_deposit", properties: { chain } });
+    },
+    [track],
+  );
+
   return {
     track,
     trackWalletConnect,
@@ -65,5 +79,7 @@ export function useAnalytics() {
     trackTxSuccess,
     trackTxFailure,
     trackPageView,
+    trackProposalVote,
+    trackTreasuryDeposit,
   };
 }

--- a/frontend/src/hooks/useGovernance.ts
+++ b/frontend/src/hooks/useGovernance.ts
@@ -146,7 +146,7 @@ export function useGovernance() {
     title: string,
     description: string,
     action: GovernanceProposalAction,
-    amount: number,
+    amount: bigint,
     target: string,
   ): Promise<void> => {
     if (!address) throw new Error("Wallet not connected");

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -27,6 +27,7 @@ import {
 } from "@/lib/treasuryMocks";
 import { useFreighter } from "./useFreighter";
 import { usePageVisibility } from "./usePageVisibility";
+import { trackEvent } from "@/lib/analytics";
 
 const REFRESH_INTERVAL = 30_000;
 const MAX_VISIBLE_TRANSACTIONS = 20;
@@ -227,6 +228,7 @@ export function useTreasury() {
           amount,
         );
         await signAndSubmit(txBuilder.build());
+        trackEvent({ name: "treasury_deposit", properties: { chain: "stellar" } });
         await refresh();
       } catch (err: unknown) {
         const appError = classifyError(err);

--- a/frontend/src/hooks/useTxLifecycle.ts
+++ b/frontend/src/hooks/useTxLifecycle.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef } from "react";
 import { type AppError, classifyError } from "@/lib/errors";
 import { createSubmitGuard } from "@/lib/submitGuard";
+import { trackEvent } from "@/lib/analytics";
 
 /**
  * Lifecycle stages of a Soroban transaction, in order.
@@ -83,6 +84,8 @@ export function useTxLifecycle() {
       sign: (built: TBuilt) => Promise<TResult>;
       /** Called with the result after the chain confirms. */
       onSuccess?: (result: TResult) => void;
+      /** Optional metadata used to emit analytics events for this transaction. */
+      meta?: { type: string; chain?: string };
     }): Promise<TResult | undefined> => {
       return submitGuardRef.current.run(async () => {
         const runId = ++runIdRef.current;
@@ -93,11 +96,16 @@ export function useTxLifecycle() {
           }
         };
 
+        const chain = steps.meta?.chain ?? "stellar";
+        const txType = steps.meta?.type ?? "unknown";
+        const startMs = Date.now();
+
         try {
           setStage("building");
           const built = await steps.build();
 
           setStage("signing");
+          trackEvent({ name: "tx_submit", properties: { type: txType, chain } });
           const result = await steps.sign(built);
           // signing stage persists while the wallet popup is open; only advance
           // to confirming once the signed transaction has been submitted.
@@ -105,6 +113,10 @@ export function useTxLifecycle() {
 
           if (runIdRef.current === runId) {
             setState({ stage: "success", error: null, canRetry: false });
+            trackEvent({
+              name: "tx_success",
+              properties: { type: txType, chain, durationMs: Date.now() - startMs },
+            });
             steps.onSuccess?.(result);
           }
 
@@ -113,6 +125,10 @@ export function useTxLifecycle() {
           if (runIdRef.current === runId) {
             const appError = classifyError(err);
             setState({ stage: "error", error: appError, canRetry: appError.recoverable });
+            trackEvent({
+              name: "tx_failure",
+              properties: { type: txType, chain, errorCode: appError.code ?? "unknown" },
+            });
           }
           throw err;
         }

--- a/frontend/src/lib/soroban.ts
+++ b/frontend/src/lib/soroban.ts
@@ -230,7 +230,7 @@ export async function buildCreateProposalTx(
   title: string,
   description: string,
   action: GovernanceProposalAction,
-  amount: number,
+  amount: bigint | number,
   target: string,
 ): Promise<TransactionBuilder> {
   const args = [
@@ -251,7 +251,7 @@ export async function buildCreateProposalXdr(
   title: string,
   description: string,
   action: GovernanceProposalAction,
-  amount: number,
+  amount: bigint | number,
   target: string,
 ): Promise<string> {
   return buildTransactionXdr(


### PR DESCRIPTION
## Summary

This PR addresses four assigned issues across the backend and frontend:

### [PERF-5] #261 — Backend DB pool has no connection limits configured
- Added `max` (default `10`, configurable via `DB_POOL_MAX`), `idleTimeoutMillis` (30 s), and `connectionTimeoutMillis` (5 s) to the `pg.Pool` constructor in `backend/src/db.ts`
- Added a pool `error` event handler to log unexpected idle-client failures
- Added `dbPoolMax` to the `Config` interface and `loadConfig()` in `backend/src/config.ts`

### [BE-19] #254 — Backend Soroban SDK version mismatch with frontend
- Bumped frontend `@stellar/stellar-sdk` from `^11.3.0` to `^12.3.0` to match the backend, preventing XDR encoding and event-parsing divergence
- Updated `frontend/package-lock.json` to reflect the resolved version
- Documented the required SDK version constraint in `CONTRIBUTING.md`

### [FE-208] #252 — TreasuryCard amount prop type is number but should be bigint
- `buildCreateProposalTx` and `buildCreateProposalXdr` in `soroban.ts` now accept `bigint | number` instead of `number`
- `useGovernance.createProposal` now accepts `bigint` for `amount`
- Removed the lossy `Number(data.amount)` cast in `governance/page.tsx`; the `bigint` value from `CreateProposalModal` now flows through without conversion

### [FE-209] #253 — Analytics useAnalytics hook is not wired to any component
- **FreighterProvider**: fires `wallet_connect` (with truncated address) and `wallet_disconnect`
- **useTxLifecycle**: fires `tx_submit` when signing begins and `tx_success`/`tx_failure` on resolution; call sites can pass optional `meta.type` / `meta.chain`
- **useTreasury**: fires `treasury_deposit` after a confirmed on-chain deposit
- **VoteButton**: fires `proposal_vote` after a successful governance vote
- **RouteTracker**: new client component added to the root layout; fires `page_view` on every Next.js pathname change
- **useAnalytics**: added `trackProposalVote` and `trackTreasuryDeposit` helper methods

Closes #252 
Closes #253 
Closes #254 
Closes #261