### PR TITLE
fix: resolve #248 #255 #275 #323 — wallet disconnect, parser events, Dockerfile, dashboard skeletons

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,32 @@
-FROM node:20-alpine
+# Build stage: compile TypeScript
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-COPY server.js .
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# Production stage
+FROM node:20-alpine
+
+RUN apk add --no-cache postgresql-client bash
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+COPY server.js indexer.js migrate.sh ./
+COPY migrations ./migrations
 
 EXPOSE 8000
 
-CMD ["node", "server.js"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD wget -qO- http://localhost:8000/health || exit 1
+
+CMD ["node", "dist/index.js"]

--- a/backend/src/parser.test.ts
+++ b/backend/src/parser.test.ts
@@ -117,6 +117,25 @@ describe("getEventName", () => {
     expect(getEventName("treasury", null)).toBeNull();
     expect(getEventName(null, null)).toBeNull();
   });
+
+  it("resolves all access-control event names", () => {
+    expect(getEventName("acl", "init")).toBe("Access Control Initialize");
+    expect(getEventName("acl", "assign")).toBe("Access Control Assign");
+    expect(getEventName("acl", "revoke")).toBe("Access Control Revoke");
+    expect(getEventName("acl", "owner")).toBe("Access Control Owner Change");
+  });
+
+  it("resolves vault emergency event names", () => {
+    expect(getEventName("vault", "emrg_ap")).toBe("Vault Emergency Approve");
+    expect(getEventName("vault", "emrg_ex")).toBe("Vault Emergency Execute");
+  });
+
+  it("resolves all vault event names", () => {
+    expect(getEventName("vault", "lock")).toBe("Vault Lock");
+    expect(getEventName("vault", "claim")).toBe("Vault Claim");
+    expect(getEventName("vault", "vest")).toBe("Vault Vest");
+    expect(getEventName("vault", "v_claim")).toBe("Vault Vesting Claim");
+  });
 });
 
 describe("parseRawEvent", () => {
@@ -152,4 +171,75 @@ describe("parseRawEvent", () => {
     expect(result.data._eventName).toBeUndefined();
     expect(result.data._topics).toEqual(["foo", "bar"]);
   });
+
+  it("resolves an access-control event end-to-end", () => {
+    const result = parseRawEvent({
+      contractId: "CACL",
+      topic: [symbolScVal("acl"), symbolScVal("assign")],
+      value: i128ScVal(0n),
+      ledger: 10,
+      pagingToken: "acl-1",
+    });
+
+    expect(result.topic1).toBe("acl");
+    expect(result.topic2).toBe("assign");
+    expect(result.eventName).toBe("Access Control Assign");
+    expect(result.data._eventName).toBe("Access Control Assign");
+    expect(result.data._topics).toEqual(["acl", "assign"]);
+  });
+
+  it("resolves a vault emergency event end-to-end", () => {
+    const result = parseRawEvent({
+      contractId: "CVAULT",
+      topic: [symbolScVal("vault"), symbolScVal("emrg_ap")],
+      value: i128ScVal(0n),
+      ledger: 20,
+      pagingToken: "vault-emrg-1",
+    });
+
+    expect(result.topic1).toBe("vault");
+    expect(result.topic2).toBe("emrg_ap");
+    expect(result.eventName).toBe("Vault Emergency Approve");
+    expect(result.data._eventName).toBe("Vault Emergency Approve");
+    expect(result.data._topics).toEqual(["vault", "emrg_ap"]);
+  });
+});
+
+describe("EVENT_NAMES cross-reference mapping", () => {
+  const EXPECTED_EVENTS: Array<[string, string, string]> = [
+    ["treasury", "deposit", "Treasury Deposit"],
+    ["treasury", "propose", "Treasury Propose"],
+    ["treasury", "approve", "Treasury Approve"],
+    ["treasury", "execute", "Treasury Execute"],
+    ["treasury", "init", "Treasury Initialize"],
+    ["treasury", "dep_tok", "Treasury Deposit Token"],
+    ["treasury", "add_sig", "Treasury Add Signer"],
+    ["treasury", "rem_sig", "Treasury Remove Signer"],
+    ["treasury", "thresh", "Treasury Threshold Change"],
+    ["treasury", "admin", "Treasury Admin Change"],
+    ["gov", "propose", "Governance Propose"],
+    ["gov", "vote", "Governance Vote"],
+    ["gov", "finalize", "Governance Finalize"],
+    ["gov", "exec", "Governance Execute"],
+    ["gov", "init", "Governance Initialize"],
+    ["gov", "admin", "Governance Admin Change"],
+    ["gov", "quorum", "Governance Quorum Change"],
+    ["vault", "lock", "Vault Lock"],
+    ["vault", "claim", "Vault Claim"],
+    ["vault", "vest", "Vault Vest"],
+    ["vault", "v_claim", "Vault Vesting Claim"],
+    ["vault", "emrg_ap", "Vault Emergency Approve"],
+    ["vault", "emrg_ex", "Vault Emergency Execute"],
+    ["acl", "init", "Access Control Initialize"],
+    ["acl", "assign", "Access Control Assign"],
+    ["acl", "revoke", "Access Control Revoke"],
+    ["acl", "owner", "Access Control Owner Change"],
+  ];
+
+  it.each(EXPECTED_EVENTS)(
+    "maps (%s, %s) → %s",
+    (topic1, topic2, expectedName) => {
+      expect(getEventName(topic1, topic2)).toBe(expectedName);
+    },
+  );
 });

--- a/backend/src/parser.ts
+++ b/backend/src/parser.ts
@@ -57,6 +57,14 @@ const EVENT_NAMES: Record<string, Record<string, string>> = {
     claim: "Vault Claim",
     vest: "Vault Vest",
     v_claim: "Vault Vesting Claim",
+    emrg_ap: "Vault Emergency Approve",
+    emrg_ex: "Vault Emergency Execute",
+  },
+  acl: {
+    init: "Access Control Initialize",
+    assign: "Access Control Assign",
+    revoke: "Access Control Revoke",
+    owner: "Access Control Owner Change",
   },
 };
 
@@ -115,9 +123,14 @@ export function parseRawEvent(rawEvent: {
   pagingToken: string;
 }): ParsedEvent {
   const { topic1, topic2, allTopics } = parseTopics(rawEvent.topic);
-  const data = parseEventData(rawEvent.value);
-
+  const rawData = parseEventData(rawEvent.value);
   const eventName = getEventName(topic1, topic2);
+
+  const data: Record<string, unknown> = {
+    ...rawData,
+    _topics: allTopics,
+    ...(eventName ? { _eventName: eventName } : {}),
+  };
 
   return {
     contractId: rawEvent.contractId,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ import { useFreighter } from "@/hooks/useFreighter";
 import { useTreasury } from "@/hooks/useTreasury";
 import { useGovernance } from "@/hooks/useGovernance";
 import { formatXlm } from "@/lib/formatters";
-import { Shimmer } from "@/components/Shimmer";
+import { MetricCardSkeleton } from "@/components/Skeletons";
 
 export default function Home() {
   const { address } = useFreighter();
@@ -44,67 +44,67 @@ export default function Home() {
 
       {/* Stats Grid */}
       <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="card text-center">
-          <p className="text-sm text-gray-400 uppercase tracking-wide">
-            Treasury Balance
-          </p>
-          {isLoading ? (
-            <div className="mt-2">
-              <Shimmer className="h-9 w-32 mx-auto" />
-            </div>
-          ) : isConnected ? (
-            <p className="text-3xl font-bold text-white mt-2">
-              {formatXlm(balance)}
-            </p>
-          ) : (
-            <>
-              <p className="text-3xl font-bold text-white mt-2">— XLM</p>
-              <p className="text-xs text-gray-500 mt-1">
-                Connect wallet to view
+        {isLoading ? (
+          <>
+            <MetricCardSkeleton />
+            <MetricCardSkeleton />
+            <MetricCardSkeleton />
+          </>
+        ) : (
+          <>
+            <div className="card text-center">
+              <p className="text-sm text-gray-400 uppercase tracking-wide">
+                Treasury Balance
               </p>
-            </>
-          )}
-        </div>
-        <div className="card text-center">
-          <p className="text-sm text-gray-400 uppercase tracking-wide">
-            Active Proposals
-          </p>
-          {isLoading ? (
-            <div className="mt-2">
-              <Shimmer className="h-9 w-20 mx-auto" />
+              {isConnected ? (
+                <p className="text-3xl font-bold text-white mt-2">
+                  {formatXlm(balance)}
+                </p>
+              ) : (
+                <>
+                  <p className="text-3xl font-bold text-white mt-2">— XLM</p>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Connect wallet to view
+                  </p>
+                </>
+              )}
             </div>
-          ) : isConnected ? (
-            <p className="text-3xl font-bold text-white mt-2">
-              {activeProposals}
-            </p>
-          ) : (
-            <>
-              <p className="text-3xl font-bold text-white mt-2">—</p>
-              <p className="text-xs text-gray-500 mt-1">
-                Connect wallet to view
+            <div className="card text-center">
+              <p className="text-sm text-gray-400 uppercase tracking-wide">
+                Active Proposals
               </p>
-            </>
-          )}
-        </div>
-        <div className="card text-center">
-          <p className="text-sm text-gray-400 uppercase tracking-wide">
-            Total Signers
-          </p>
-          {isLoading ? (
-            <div className="mt-2">
-              <Shimmer className="h-9 w-16 mx-auto" />
+              {isConnected ? (
+                <p className="text-3xl font-bold text-white mt-2">
+                  {activeProposals}
+                </p>
+              ) : (
+                <>
+                  <p className="text-3xl font-bold text-white mt-2">—</p>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Connect wallet to view
+                  </p>
+                </>
+              )}
             </div>
-          ) : isConnected ? (
-            <p className="text-3xl font-bold text-white mt-2">{totalSigners}</p>
-          ) : (
-            <>
-              <p className="text-3xl font-bold text-white mt-2">—</p>
-              <p className="text-xs text-gray-500 mt-1">
-                Connect wallet to view
+            <div className="card text-center">
+              <p className="text-sm text-gray-400 uppercase tracking-wide">
+                Total Signers
               </p>
-            </>
-          )}
-        </div>
+              {isConnected ? (
+                <p className="text-3xl font-bold text-white mt-2">
+                  {totalSigners}
+                </p>
+              ) : (
+                <>
+                  <p className="text-3xl font-bold text-white mt-2">—</p>
+                  <p className="text-xs text-gray-500 mt-1">
+                    Connect wallet to view
+                  </p>
+                </>
+              )}
+            </div>
+          </>
+        )}
       </section>
 
       {/* Empty State for When No Data is Available */}

--- a/frontend/src/components/Skeletons.tsx
+++ b/frontend/src/components/Skeletons.tsx
@@ -17,6 +17,27 @@ function Bone({ className }: { className?: string }) {
   );
 }
 
+// ── Metric card skeleton (dashboard, #323) ───────────────────────────────
+
+/**
+ * Compact skeleton for the three dashboard metric cards (Treasury Balance,
+ * Active Proposals, Total Signers). Preserves card dimensions during initial
+ * load and uses the same bg-white/10 pattern as RouteSkeleton.
+ */
+export function MetricCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn("card text-center animate-pulse", className)}
+      aria-label="Loading metric"
+      aria-busy="true"
+    >
+      <Bone className="h-3.5 w-28 mx-auto" />
+      <Bone className="h-9 w-24 mx-auto mt-2" />
+      <span className="sr-only">Loading…</span>
+    </div>
+  );
+}
+
 // ── Stats card skeleton (#114) ────────────────────────────────────────────
 
 /**

--- a/frontend/src/hooks/useGovernance.ts
+++ b/frontend/src/hooks/useGovernance.ts
@@ -338,6 +338,16 @@ export function useGovernance() {
     }
   }, [fetchConfig]);
 
+  // Clear stale data and cancel in-flight requests when the wallet disconnects.
+  useEffect(() => {
+    if (!address) {
+      requestGuardRef.current.cancel("Wallet disconnected.");
+      setConfig(null);
+      setPendingVotes(new Map());
+      setError(null);
+    }
+  }, [address]);
+
   useEffect(() => {
     refresh();
     const interval = setInterval(() => {

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -441,6 +441,18 @@ export function useTreasury() {
     setError(null);
   }, []);
 
+  // Clear stale data and cancel in-flight requests when the wallet disconnects.
+  useEffect(() => {
+    if (!address) {
+      requestGuardRef.current.cancel("Wallet disconnected.");
+      setBalance(BigInt(0));
+      setConfig(null);
+      setTransactions([]);
+      setError(null);
+      setTxActions(new Map());
+    }
+  }, [address]);
+
   useEffect(() => {
     const requestGuard = requestGuardRef.current;
     refresh();


### PR DESCRIPTION
## Summary



Closes #275 — Backend Dockerfile missing from repository [DO-19]
Closes #255 — Backend missing proposal and vault event handlers in parser [BE-20]
Closes #248 — Wallet disconnect does not clear hook data [FE-204]
Closes #323 — Add dashboard loading skeletons for metric cards [FE-214]

---

### [DO-19 #275] Fix backend Dockerfile

The previous `backend/Dockerfile` was a placeholder that only ran `server.js`. Replaced with a proper **multi-stage build**:

- **Builder stage** — installs all deps and compiles TypeScript via `npm run build`
- **Runtime stage** — installs only production deps, copies `dist/`, `server.js`, `indexer.js`, `migrate.sh`, and `migrations/`
- Adds `postgresql-client` + `bash` so `migrate.sh` can run inside the container
- Exposes port `8000`
- Adds `HEALTHCHECK` via `wget` against `/health`
- `CMD ["node", "dist/index.js"]` — the indexer service can override this with `command: node indexer.js` as already defined in `docker-compose.yml`

---

### [BE-20 #255] Add parser event names + fix `parseRawEvent`

**`backend/src/parser.ts`**

- Added `acl` contract event group: `init`, `assign`, `revoke`, `owner`
- Added vault emergency events: `emrg_ap` (Vault Emergency Approve), `emrg_ex` (Vault Emergency Execute)
- Fixed `parseRawEvent` to merge `_topics` (always) and `_eventName` (when known) into the returned `data` object — required by the existing test assertions in `parser.test.ts`

**`backend/src/parser.test.ts`**

- Added `getEventName` tests covering all ACL events and vault emergency events
- Added `getEventName` tests covering all existing vault events for completeness
- Added two end-to-end `parseRawEvent` tests (ACL assign, vault emrg_ap)
- Added a `describe("EVENT_NAMES cross-reference mapping")` block with `it.each` covering all 27 known (topic1, topic2) pairs

---

### [FE-204 #248] Clear hook state on wallet disconnect

**`frontend/src/hooks/useTreasury.ts`**

Added a `useEffect` that fires when `address` becomes `null`:
- Cancels all in-flight requests via `requestGuardRef.current.cancel()`
- Resets `balance`, `config`, `transactions`, `txActions`, and `error` to their initial values

**`frontend/src/hooks/useGovernance.ts`**

Same pattern — on `address → null`:
- Cancels in-flight requests
- Resets `config`, `pendingVotes`, and `error`

---

### [FE-214 #323] Dashboard metric card skeletons

**`frontend/src/components/Skeletons.tsx`**

Added `MetricCardSkeleton` — a compact, centered skeleton with an animated label bone and a tall value bone. Uses the same `animate-pulse` + `bg-white/8` pattern as the rest of `Skeletons.tsx` and `RouteSkeleton.tsx`.

**`frontend/src/app/page.tsx`**

- Replaced three inline `<Shimmer>` wrappers with `<MetricCardSkeleton />` instances
- Loading branch now renders all three card skeletons together; connected/disconnected branches remain unchanged
- Removed the `Shimmer` import (no longer used on this page)

---

## Test plan

- [ ] `cd backend && npm test` — all parser tests pass, including the new ACL + cross-reference suite
- [ ] `docker compose build` succeeds with the new multi-stage Dockerfile
- [ ] Connect Freighter wallet on the dashboard → metric cards show skeletons while loading, then display real values
- [ ] Disconnect wallet → Treasury and Governance pages show "Connect wallet" state with no stale data
- [ ] Re-connect wallet → data refreshes correctly

