### PR TITLE
fix: configurable TX timeout, parallel fetch race, Freighter reinstal…

### DIFF
--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -14,12 +14,21 @@ const STATUS_STYLES: Record<ProposalStatus, string> = {
   Expired: "bg-gray-900/50 text-gray-300 border-gray-700",
 };
 
+const STATUS_ICONS: Record<ProposalStatus, string> = {
+  Active: "●",
+  Passed: "✓",
+  Rejected: "✗",
+  Executed: "✓",
+  Expired: "○",
+};
+
 export function StatusBadge({ status, size = "sm" }: StatusBadgeProps) {
   const sizeClass = size === "md" ? "px-3 py-1 text-sm" : "px-2 py-0.5 text-xs";
   return (
     <span
-      className={`inline-flex items-center rounded-full border font-semibold ${sizeClass} ${STATUS_STYLES[status]}`}
+      className={`inline-flex items-center gap-1 rounded-full border font-semibold ${sizeClass} ${STATUS_STYLES[status]}`}
     >
+      <span aria-hidden="true">{STATUS_ICONS[status]}</span>
       {status}
     </span>
   );

--- a/frontend/src/components/TreasuryCard.tsx
+++ b/frontend/src/components/TreasuryCard.tsx
@@ -71,16 +71,16 @@ export const TreasuryCard: React.FC<TreasuryCardProps> = ({
         </div>
         <div>
           {executed ? (
-            <span className="inline-flex items-center rounded-full bg-green-500/10 px-2.5 py-0.5 text-xs font-medium text-green-500 border border-green-500/20">
-              Executed
+            <span className="inline-flex items-center gap-1 rounded-full bg-green-500/10 px-2.5 py-0.5 text-xs font-medium text-green-500 border border-green-500/20">
+              <span aria-hidden="true">✓</span> Executed
             </span>
           ) : isReadyToExecute ? (
-            <span className="inline-flex items-center rounded-full bg-blue-500/10 px-2.5 py-0.5 text-xs font-medium text-blue-500 border border-blue-500/20">
-              Ready to Execute
+            <span className="inline-flex items-center gap-1 rounded-full bg-blue-500/10 px-2.5 py-0.5 text-xs font-medium text-blue-500 border border-blue-500/20">
+              <span aria-hidden="true">▶</span> Ready to Execute
             </span>
           ) : (
-            <span className="inline-flex items-center rounded-full bg-yellow-500/10 px-2.5 py-0.5 text-xs font-medium text-yellow-500 border border-yellow-500/20">
-              Pending Approvals
+            <span className="inline-flex items-center gap-1 rounded-full bg-yellow-500/10 px-2.5 py-0.5 text-xs font-medium text-yellow-500 border border-yellow-500/20">
+              <span aria-hidden="true">○</span> Pending Approvals
             </span>
           )}
         </div>

--- a/frontend/src/context/FreighterProvider.tsx
+++ b/frontend/src/context/FreighterProvider.tsx
@@ -58,6 +58,12 @@ export const FreighterProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     checkConnection();
   }, [checkConnection]);
 
+  useEffect(() => {
+    const handleFocus = () => void checkConnection();
+    window.addEventListener("focus", handleFocus);
+    return () => window.removeEventListener("focus", handleFocus);
+  }, [checkConnection]);
+
   const connect = async () => {
     setIsConnecting(true);
     setError(null);

--- a/frontend/src/hooks/useTreasury.ts
+++ b/frontend/src/hooks/useTreasury.ts
@@ -69,46 +69,23 @@ export function useTreasury() {
   }, []);
 
   const fetchBalance = useCallback(
-    async (requestId: number, signal: AbortSignal) => {
-      const result = await readContractValue(
-        CONTRACT_IDS.treasury,
-        "get_balance",
-        [],
-        {
-          decoder: decodeBigInt,
-          signal,
-          sourceAddress: address ?? undefined,
-        },
-      );
-
-      if (requestGuardRef.current.isCurrent(requestId)) {
-        setBalance(result);
-      }
-
-      return result;
+    async (signal: AbortSignal) => {
+      return readContractValue(CONTRACT_IDS.treasury, "get_balance", [], {
+        decoder: decodeBigInt,
+        signal,
+        sourceAddress: address ?? undefined,
+      });
     },
     [address],
   );
 
   const fetchConfig = useCallback(
-    async (requestId: number, signal: AbortSignal) => {
-      const result = await readContractValue(
-        CONTRACT_IDS.treasury,
-        "get_config",
-        [],
-        {
-          decoder: decodeTreasuryConfig,
-          signal,
-          sourceAddress: address ?? undefined,
-        },
-      );
-
-      if (requestGuardRef.current.isCurrent(requestId)) {
-        setConfig(result);
-        setBalance(result.balance);
-      }
-
-      return result;
+    async (signal: AbortSignal) => {
+      return readContractValue(CONTRACT_IDS.treasury, "get_config", [], {
+        decoder: decodeTreasuryConfig,
+        signal,
+        sourceAddress: address ?? undefined,
+      });
     },
     [address],
   );
@@ -181,8 +158,8 @@ export function useTreasury() {
 
     try {
       const [currentBalance, currentConfig] = await Promise.all([
-        fetchBalance(request.id, request.signal),
-        fetchConfig(request.id, request.signal),
+        fetchBalance(request.signal),
+        fetchConfig(request.signal),
       ]);
 
       await fetchTransactions(
@@ -192,6 +169,7 @@ export function useTreasury() {
       );
 
       if (requestGuardRef.current.isCurrent(request.id)) {
+        setConfig(currentConfig);
         setBalance(currentConfig.balance ?? currentBalance);
       }
     } catch (err: unknown) {

--- a/frontend/src/lib/network.ts
+++ b/frontend/src/lib/network.ts
@@ -60,6 +60,14 @@ export const ACTIVE_NETWORK_KEY = Object.entries(NETWORKS).find(
   ([, network]) => network.networkPassphrase === NETWORK_PASSPHRASE,
 )?.[0] as keyof typeof NETWORKS | undefined;
 
+/**
+ * Transaction time-bound in seconds. Configurable via NEXT_PUBLIC_TX_TIMEOUT.
+ * Defaults to 300 s on mainnet (slow wallets need more time) and 30 s elsewhere.
+ */
+export const TX_TIMEOUT =
+  Number(process.env.NEXT_PUBLIC_TX_TIMEOUT) ||
+  (ACTIVE_NETWORK_KEY === "mainnet" ? 300 : 30);
+
 // ============================================================================
 // Helpers
 // ============================================================================

--- a/frontend/src/lib/soroban.ts
+++ b/frontend/src/lib/soroban.ts
@@ -20,7 +20,7 @@ import type { GovernanceProposalAction } from "./contractData";
 import type { Decoder } from "./sorobanClient";
 import { readPublicEnv, requirePublicEnv } from "./env";
 import { throwIfAborted } from "./requestGuard";
-import { NETWORK_PASSPHRASE } from "./network";
+import { NETWORK_PASSPHRASE, TX_TIMEOUT } from "./network";
 import { sorobanClient } from "./sorobanClient";
 
 // ============================================================================
@@ -63,7 +63,7 @@ export async function buildContractCall(
     networkPassphrase: NETWORK_PASSPHRASE,
   })
     .addOperation(contract.call(method, ...args))
-    .setTimeout(30);
+    .setTimeout(TX_TIMEOUT);
 
   return tx;
 }

--- a/frontend/src/lib/sorobanClient.ts
+++ b/frontend/src/lib/sorobanClient.ts
@@ -14,7 +14,7 @@ import {
   xdr,
   scValToNative,
 } from "@stellar/stellar-sdk";
-import { SOROBAN_RPC_URL, NETWORK_PASSPHRASE } from "./network";
+import { SOROBAN_RPC_URL, NETWORK_PASSPHRASE, TX_TIMEOUT } from "./network";
 
 // ── Poll policy ───────────────────────────────────────────────────────────────
 
@@ -118,7 +118,7 @@ export class SorobanClient {
       networkPassphrase: NETWORK_PASSPHRASE,
     })
       .addOperation(new Contract(contractId).call(method, ...args))
-      .setTimeout(30)
+      .setTimeout(TX_TIMEOUT)
       .build();
 
     const sim = await this.simulate(tx, signal);


### PR DESCRIPTION
…l detection, a11y icons

- FE-210: TX_TIMEOUT in network.ts (env-overridable, 300s mainnet / 30s others); used in soroban.ts and sorobanClient.ts
- PERF-6: fetchBalance/fetchConfig no longer set state individually; refresh() sets config+balance once after both promises resolve, eliminating redundant renders and race writes
- RQ-10: FreighterProvider now re-checks Freighter on window focus so reinstall is detected without page reload
- A11Y-6: StatusBadge and TreasuryCard status spans include icon (●✓✗○▶) alongside text label, satisfying WCAG 1.4.1

## Summary
<!-- Briefly describe what this PR does and why -->

## Related Issue
Closes #269 
Closes #270 
Closes #271 
Closes #264 


## Changes
- 

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Self-reviewed the changes
- [ ] Tests added/updated and passing
- [ ] No breaking changes (or breaking changes documented)
- [ ] Documentation updated if needed
