### PR TITLE
feat(multi): cancel proposals, Redis cache, tests, and loading states

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "@stellar/stellar-sdk": "^12.3.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
+    "ioredis": "^5.3.2",
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@nestjs/testing": "^10.4.22",
     "@types/express": "^5.0.6",
+    "@types/ioredis": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.5",
     "@types/pg": "^8.11.11",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { VaultService } from "./vault/vault.service";
 import { ListenerService } from "./listener.service";
 import { ApiKeyGuard } from "./guards/api-key.guard";
 import { RequestLoggerMiddleware } from "./middleware/request-logger.middleware";
+import { CacheModule } from "./cache/cache.module";
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { RequestLoggerMiddleware } from "./middleware/request-logger.middleware"
         limit: 100, // 100 requests
       },
     ]),
+    CacheModule,
   ],
   controllers: [
     HealthController,

--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CacheService } from './cache.service';
+
+@Module({
+  providers: [CacheService],
+  exports: [CacheService],
+})
+export class CacheModule {}

--- a/backend/src/cache/cache.service.ts
+++ b/backend/src/cache/cache.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common';
+import Redis from 'ioredis';
+import { config } from '../config';
+
+@Injectable()
+export class CacheService {
+  private redis: Redis;
+  private readonly logger = new Logger(CacheService.name);
+
+  constructor() {
+    this.redis = new Redis(config.redisUrl);
+    this.redis.on('error', (err) =>
+      this.logger.error('Redis client error', err),
+    );
+    this.redis.on('connect', () =>
+      this.logger.log('Connected to Redis'),
+    );
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    try {
+      const value = await this.redis.get(key);
+      if (!value) return null;
+      return JSON.parse(value) as T;
+    } catch (error) {
+      this.logger.error(`Error getting cache key ${key}:`, error);
+      return null;
+    }
+  }
+
+  async set<T>(key: string, value: T, ttlSeconds: number = 60): Promise<void> {
+    try {
+      await this.redis.setex(key, ttlSeconds, JSON.stringify(value));
+    } catch (error) {
+      this.logger.error(`Error setting cache key ${key}:`, error);
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    try {
+      await this.redis.del(key);
+    } catch (error) {
+      this.logger.error(`Error deleting cache key ${key}:`, error);
+    }
+  }
+
+  async invalidatePattern(pattern: string): Promise<void> {
+    try {
+      const keys = await this.redis.keys(pattern);
+      if (keys.length > 0) {
+        await this.redis.del(...keys);
+      }
+    } catch (error) {
+      this.logger.error(`Error invalidating cache pattern ${pattern}:`, error);
+    }
+  }
+
+  async flush(): Promise<void> {
+    try {
+      await this.redis.flushdb();
+      this.logger.log('Redis cache flushed');
+    } catch (error) {
+      this.logger.error('Error flushing Redis cache:', error);
+    }
+  }
+
+  async onModuleDestroy() {
+    await this.redis.quit();
+  }
+}

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -5,6 +5,7 @@ dotenv.config({ path: path.resolve(__dirname, "..", ".env") });
 
 export interface Config {
   databaseUrl: string;
+  redisUrl: string;
   sorobanRpcUrl: string;
   networkPassphrase: string;
   contractIds: string[];
@@ -132,6 +133,7 @@ export function loadConfig(): Config {
 
   const pollIntervalMs = parseInt(process.env.POLL_INTERVAL_MS || "5000", 10);
   const dbPoolMax = parseInt(process.env.DB_POOL_MAX || "10", 10);
+  const redisUrl = process.env.REDIS_URL || "redis://localhost:6379";
   const contractIds = getContractIds();
   const corsOrigin = parseCorsOrigin(nodeEnv);
 
@@ -153,6 +155,7 @@ export function loadConfig(): Config {
 
   const config: Config = {
     databaseUrl,
+    redisUrl,
     sorobanRpcUrl,
     networkPassphrase,
     contractIds,

--- a/backend/src/governance/governance.service.ts
+++ b/backend/src/governance/governance.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { pool } from "../db";
+import { CacheService } from "../cache/cache.service";
 import { z } from "zod";
 
 export const ProposalSchema = z.object({
@@ -41,6 +42,8 @@ export interface Proposal {
 @Injectable()
 export class GovernanceService {
   private readonly logger = new Logger(GovernanceService.name);
+
+  constructor(private readonly cache: CacheService) {}
 
   async getProposals(
     page: number = 1,
@@ -118,9 +121,15 @@ export class GovernanceService {
   }
 
   async getMembers(): Promise<string[]> {
+    const cacheKey = "governance:members";
+    const cached = await this.cache.get<string[]>(cacheKey);
+    if (cached) return cached;
+
     // In a real implementation, this would query the contract
     // For now, return mock members
-    return ["GABC123...", "GDEF456...", "GHIJ789..."];
+    const members = ["GABC123...", "GDEF456...", "GHIJ789..."];
+    await this.cache.set(cacheKey, members, 300);
+    return members;
   }
 
   async getConfig(): Promise<GovernanceConfig> {
@@ -130,14 +139,20 @@ export class GovernanceService {
       throw new Error("GOVERNANCE_CONTRACT_ID not configured");
     }
 
+    const cacheKey = `governance:config:${contractId}`;
+    const cached = await this.cache.get<GovernanceConfig>(cacheKey);
+    if (cached) return cached;
+
     // In a real implementation, this would query the contract
-    return {
+    const configData = {
       admin: "GADMIN...",
       member_count: 3,
       quorum_percent: 50,
       voting_period: 1000,
       proposal_count: 10,
     };
+    await this.cache.set(cacheKey, configData, 60);
+    return configData;
   }
 
   async getProposalVotes(id: string) {

--- a/backend/src/treasury/treasury.service.ts
+++ b/backend/src/treasury/treasury.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { SorobanRpc } from "@stellar/stellar-sdk";
 import { config } from "../config";
 import { pool } from "../db";
+import { CacheService } from "../cache/cache.service";
 import { z } from "zod";
 
 // Define transaction schema for validation
@@ -24,7 +25,7 @@ export class TreasuryService {
   private readonly logger = new Logger(TreasuryService.name);
   private readonly server: SorobanRpc.Server;
 
-  constructor() {
+  constructor(private readonly cache: CacheService) {
     this.server = new SorobanRpc.Server(config.sorobanRpcUrl);
   }
 
@@ -32,24 +33,36 @@ export class TreasuryService {
     const contractId = process.env.TREASURY_CONTRACT_ID;
     if (!contractId) throw new Error("TREASURY_CONTRACT_ID not configured");
 
+    const cacheKey = `treasury:balance:${contractId}`;
+    const cached = await this.cache.get<string>(cacheKey);
+    if (cached) return cached;
+
     // For now, return a placeholder balance
     // In a real implementation, this would query the contract via RPC
     // or read from the indexed database
-    return "1000.0000000";
+    const balance = "1000.0000000";
+    await this.cache.set(cacheKey, balance, 30);
+    return balance;
   }
 
   async getConfig() {
     const contractId = process.env.TREASURY_CONTRACT_ID;
     if (!contractId) throw new Error("TREASURY_CONTRACT_ID not configured");
 
+    const cacheKey = `treasury:config:${contractId}`;
+    const cached = await this.cache.get(cacheKey);
+    if (cached) return cached;
+
     // Mocking config return based on contract struct
-    return {
+    const configData = {
       admin: "G...",
       threshold: 2,
       signer_count: 3,
       balance: "1000000000",
       tx_count: 10,
     };
+    await this.cache.set(cacheKey, configData, 60);
+    return configData;
   }
 
   async getTransactions(page: number = 1, limit: number = 10) {
@@ -72,6 +85,12 @@ export class TreasuryService {
   }
 
   async getSigners() {
-    return ["GBVQBPV3...", "GDI67..."];
+    const cacheKey = "treasury:signers";
+    const cached = await this.cache.get<string[]>(cacheKey);
+    if (cached) return cached;
+
+    const signers = ["GBVQBPV3...", "GDI67..."];
+    await this.cache.set(cacheKey, signers, 300);
+    return signers;
   }
 }

--- a/backend/src/vault/vault.service.ts
+++ b/backend/src/vault/vault.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { pool } from "../db";
+import { CacheService } from "../cache/cache.service";
 import { z } from "zod";
 
 export const LockSchema = z.object({
@@ -45,6 +46,8 @@ export interface VaultStats {
 @Injectable()
 export class VaultService {
   private readonly logger = new Logger(VaultService.name);
+
+  constructor(private readonly cache: CacheService) {}
 
   async getLocks(page: number = 1, limit: number = 10) {
     const offset = (page - 1) * limit;
@@ -159,13 +162,19 @@ export class VaultService {
       throw new Error("TOKEN_VAULT_CONTRACT_ID not configured");
     }
 
+    const cacheKey = `vault:stats:${contractId}`;
+    const cached = await this.cache.get<VaultStats>(cacheKey);
+    if (cached) return cached;
+
     // In a real implementation, this would aggregate from the database
-    return {
+    const stats = {
       total_locked: "50000000000",
       total_vesting: "100000000000",
       total_claimed: "20000000000",
       active_locks: 15,
       active_vestings: 8,
     };
+    await this.cache.set(cacheKey, stats, 60);
+    return stats;
   }
 }

--- a/smartcontract/contracts/treasury/src/lib.rs
+++ b/smartcontract/contracts/treasury/src/lib.rs
@@ -39,6 +39,8 @@ pub enum Error {
     NotASigner = 11,
     /// Cannot remove signer — would breach threshold.
     ThresholdBreach = 12,
+    /// Transaction has been canceled.
+    Canceled = 13,
 }
 
 // ============================================================================
@@ -87,6 +89,8 @@ pub struct Transaction {
     pub approvals: Vec<Address>,
     /// Whether the transaction has been executed.
     pub executed: bool,
+    /// Whether the transaction has been canceled.
+    pub canceled: bool,
     /// Timestamp when the transaction was proposed.
     pub created_at: u64,
     /// Address that proposed the transaction.
@@ -372,6 +376,7 @@ impl TreasuryContract {
             memo: memo.clone(),
             approvals,
             executed: false,
+            canceled: false,
             created_at: env.ledger().timestamp(),
             proposer: proposer.clone(),
         };
@@ -432,6 +437,10 @@ impl TreasuryContract {
 
         if transaction.executed {
             return Err(Error::AlreadyExecuted);
+        }
+
+        if transaction.canceled {
+            return Err(Error::Canceled);
         }
 
         // Check if already approved by this signer
@@ -497,6 +506,10 @@ impl TreasuryContract {
 
         if transaction.executed {
             return Err(Error::AlreadyExecuted);
+        }
+
+        if transaction.canceled {
+            return Err(Error::Canceled);
         }
 
         // Check threshold
@@ -566,6 +579,80 @@ impl TreasuryContract {
             tx_id,
             transaction.amount,
             transaction.to
+        );
+        Ok(())
+    }
+
+    /// Cancel a pending withdrawal transaction.
+    /// Only the proposer or admin can cancel a transaction that has not been executed.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment.
+    /// * `caller` - The address requesting cancellation (proposer or admin).
+    /// * `tx_id` - The ID of the transaction to cancel.
+    ///
+    /// # Returns
+    /// Ok(()) on successful cancellation.
+    ///
+    /// # Errors
+    /// * `Error::NotInitialized` - If the contract is not initialized.
+    /// * `Error::TransactionNotFound` - If the transaction doesn't exist.
+    /// * `Error::AlreadyExecuted` - If the transaction is already executed.
+    /// * `Error::Unauthorized` - If caller is not the proposer or admin.
+    /// * `Error::Canceled` - If transaction is already canceled.
+    pub fn cancel_transaction(env: Env, caller: Address, tx_id: u64) -> Result<(), Error> {
+        Self::require_initialized(&env)?;
+
+        caller.require_auth();
+
+        let mut transaction: Transaction = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Transaction(tx_id))
+            .ok_or(Error::TransactionNotFound)?;
+
+        if transaction.executed {
+            return Err(Error::AlreadyExecuted);
+        }
+
+        if transaction.canceled {
+            return Err(Error::Canceled);
+        }
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+
+        if caller != transaction.proposer && caller != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        transaction.canceled = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transaction(tx_id), &transaction);
+
+        let reserved: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Reserved)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::Reserved, &(reserved - transaction.amount));
+
+        env.events().publish(
+            (symbol_short!("treasury"), symbol_short!("cancel")),
+            (tx_id, caller.clone()),
+        );
+
+        log!(
+            &env,
+            "Transaction #{} canceled by {:?}",
+            tx_id,
+            caller
         );
         Ok(())
     }
@@ -1755,5 +1842,181 @@ mod test {
         // Try to approve after execution
         let result = client.try_approve(&signer1, &tx_id);
         assert_eq!(result, Err(Ok(Error::AlreadyExecuted)));
+    }
+
+    #[test]
+    fn test_cancel_by_proposer() {
+        let (env, admin, _contract_id, client) = setup_contract();
+        let signer1 = Address::generate(&env);
+        let signers = Vec::from_array(&env, [signer1.clone()]);
+        let asset = initialize_treasury(&client, &env, &admin, 1, &signers);
+
+        mint_asset(&env, &asset, &signer1, 5_000_000);
+        client.deposit(&signer1, &5_000_000);
+        let recipient = Address::generate(&env);
+        let tx_id = client.propose_withdrawal(
+            &signer1,
+            &recipient,
+            &1_000_000,
+            &String::from_str(&env, "test withdrawal"),
+        );
+
+        client.cancel_transaction(&signer1, &tx_id);
+
+        let tx = client.get_transaction(&tx_id);
+        assert!(tx.canceled);
+        assert!(!tx.executed);
+    }
+
+    #[test]
+    fn test_cancel_by_admin() {
+        let (env, admin, _contract_id, client) = setup_contract();
+        let signer1 = Address::generate(&env);
+        let signers = Vec::from_array(&env, [signer1.clone()]);
+        let asset = initialize_treasury(&client, &env, &admin, 1, &signers);
+
+        mint_asset(&env, &asset, &signer1, 5_000_000);
+        client.deposit(&signer1, &5_000_000);
+        let recipient = Address::generate(&env);
+        let tx_id = client.propose_withdrawal(
+            &signer1,
+            &recipient,
+            &1_000_000,
+            &String::from_str(&env, "test withdrawal"),
+        );
+
+        client.cancel_transaction(&admin, &tx_id);
+
+        let tx = client.get_transaction(&tx_id);
+        assert!(tx.canceled);
+    }
+
+    #[test]
+    fn test_cancel_unauthorized() {
+        let (env, admin, _contract_id, client) = setup_contract();
+        let signer1 = Address::generate(&env);
+        let other = Address::generate(&env);
+        let signers = Vec::from_array(&env, [signer1.clone()]);
+        let asset = initialize_treasury(&client, &env, &admin, 1, &signers);
+
+        mint_asset(&env, &asset, &signer1, 5_000_000);
+        client.deposit(&signer1, &5_000_000);
+        let recipient = Address::generate(&env);
+        let tx_id = client.propose_withdrawal(
+            &signer1,
+            &recipient,
+            &1_000_000,
+            &String::from_str(&env, "test withdrawal"),
+        );
+
+        let result = client.try_cancel_transaction(&other, &tx_id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn test_cancel_executed_transaction() {
+        let (env, admin, _contract_id, client) = setup_contract();
+        let signer1 = Address::generate(&env);
+        let signers = Vec::from_array(&env, [signer1.clone()]);
+        let asset = initialize_treasury(&client, &env, &admin, 1, &signers);
+
+        mint_asset(&env, &asset, &signer1, 5_000_000);
+        client.deposit(&signer1, &5_000_000);
+        let recipient = Address::generate(&env);
+        let tx_id = client.propose_withdrawal(
+            &signer1,
+            &recipient,
+            &1_000_000,
+            &String::from_str(&env, "test withdrawal"),
+        );
+
+        client.execute(&signer1, &tx_id);
+
+        let result = client.try_cancel_transaction(&signer1, &tx_id);
+        assert_eq!(result, Err(Ok(Error::AlreadyExecuted)));
+    }
+
+    #[test]
+    fn test_cancel_already_canceled() {
+        let (env, admin, _contract_id, client) = setup_contract();
+        let signer1 = Address::generate(&env);
+        let signers = Vec::from_array(&env, [signer1.clone()]);
+        let asset = initialize_treasury(&client, &env, &admin, 1, &signers);
+
+        mint_asset(&env, &asset, &signer1, 5_000_000);
+        client.deposit(&signer1, &5_000_000);
+        let recipient = Address::generate(&env);
+        let tx_id = client.propose_withdrawal(
+            &signer1,
+            &recipient,
+            &1_000_000,
+            &String::from_str(&env, "test withdrawal"),
+        );
+
+        client.cancel_transaction(&signer1, &tx_id);
+
+        let result = client.try_cancel_transaction(&signer1, &tx_id);
+        assert_eq!(result, Err(Ok(Error::Canceled)));
+    }
+
+    #[test]
+    fn test_cancel_unreserves_funds() {
+        let (env, admin, _contract_id, client) = setup_contract();
+        let signer1 = Address::generate(&env);
+        let signers = Vec::from_array(&env, [signer1.clone()]);
+        let asset = initialize_treasury(&client, &env, &admin, 1, &signers);
+
+        mint_asset(&env, &asset, &signer1, 10_000_000);
+        client.deposit(&signer1, &10_000_000);
+
+        let recipient = Address::generate(&env);
+        let tx_id1 = client.propose_withdrawal(
+            &signer1,
+            &recipient,
+            &3_000_000,
+            &String::from_str(&env, "first proposal"),
+        );
+
+        let result = client.try_propose_withdrawal(
+            &signer1,
+            &recipient,
+            &8_000_000,
+            &String::from_str(&env, "second proposal"),
+        );
+        assert_eq!(result, Err(Ok(Error::InsufficientFunds)));
+
+        client.cancel_transaction(&signer1, &tx_id1);
+
+        let tx_id2 = client.propose_withdrawal(
+            &signer1,
+            &recipient,
+            &8_000_000,
+            &String::from_str(&env, "second proposal after cancel"),
+        );
+        assert_eq!(tx_id2, 2);
+    }
+
+    #[test]
+    fn test_approve_canceled_transaction() {
+        let (env, admin, _contract_id, client) = setup_contract();
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+        let signers = Vec::from_array(&env, [signer1.clone(), signer2.clone()]);
+        let asset = initialize_treasury(&client, &env, &admin, 2, &signers);
+
+        mint_asset(&env, &asset, &signer1, 5_000_000);
+        client.deposit(&signer1, &5_000_000);
+        let recipient = Address::generate(&env);
+        let tx_id = client.propose_withdrawal(
+            &signer1,
+            &recipient,
+            &1_000_000,
+            &String::from_str(&env, "test withdrawal"),
+        );
+
+        client.cancel_transaction(&signer1, &tx_id);
+
+        let result = client.try_approve(&signer2, &tx_id);
+        assert_eq!(result, Err(Ok(Error::Canceled)));
     }
 }

--- a/smartcontract/tests/integration/src/lib.rs
+++ b/smartcontract/tests/integration/src/lib.rs
@@ -224,4 +224,192 @@ mod workflows {
             symbol_short!("emrg_ex").into_val(env),
         );
     }
+
+    #[test]
+    fn edge_case_single_signer_treasury() {
+        let contracts = setup();
+        let env = &contracts.env;
+
+        let admin = Address::generate(env);
+        let signer = Address::generate(env);
+        let token_admin = Address::generate(env);
+        let asset = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        StellarAssetClient::new(env, &asset).mint(&signer, &1_000_000);
+        let recipient = Address::generate(env);
+        let signers = Vec::from_array(env, [signer.clone()]);
+
+        contracts.treasury.initialize(&admin, &1, &signers, &asset);
+        contracts.treasury.deposit(&signer, &1_000_000);
+
+        let tx_id = contracts.treasury.propose_withdrawal(
+            &signer,
+            &recipient,
+            &500_000,
+            &text(env, "single signer withdrawal"),
+        );
+
+        contracts.treasury.execute(&signer, &tx_id);
+        assert!(contracts.treasury.get_transaction(&tx_id).executed);
+        assert_eq!(contracts.treasury.get_balance(), 500_000);
+    }
+
+    #[test]
+    fn edge_case_governance_100_percent_quorum() {
+        let contracts = setup();
+        let env = &contracts.env;
+
+        let owner = Address::generate(env);
+        let member1 = Address::generate(env);
+        let member2 = Address::generate(env);
+        let members = Vec::from_array(env, [member1.clone(), member2.clone()]);
+
+        contracts.governance.initialize(&owner, &members, &100, &100);
+
+        let proposal_id = contracts.governance.create_proposal(
+            &member1,
+            &text(env, "100% Quorum Proposal"),
+            &text(env, "All members must vote"),
+            &ProposalAction::General,
+            &0,
+            &Address::generate(env),
+        );
+
+        contracts.governance.vote(&member1, &proposal_id, &true);
+        contracts.governance.vote(&member2, &proposal_id, &true);
+
+        env.ledger().set_timestamp(200);
+        contracts.governance.finalize(&member1, &proposal_id);
+
+        let proposal = contracts.governance.get_proposal(&proposal_id);
+        assert_eq!(proposal.status, ProposalStatus::Passed);
+    }
+
+    #[test]
+    fn edge_case_vault_zero_cliff_period() {
+        let contracts = setup();
+        let env = &contracts.env;
+
+        let admin = Address::generate(env);
+        let beneficiary = Address::generate(env);
+        let token_admin = Address::generate(env);
+        let asset = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        StellarAssetClient::new(env, &asset).mint(&admin, &10_000_000);
+
+        let signer1 = Address::generate(env);
+        let signer2 = Address::generate(env);
+        let signers = Vec::from_array(env, [signer1, signer2]);
+
+        contracts.vault.initialize(&admin, &signers, &2, &asset);
+
+        let vesting_id = contracts.vault.create_vesting(
+            &admin,
+            &beneficiary,
+            &10_000_000,
+            &365 * 86400,
+            &0,
+            &text(env, "zero cliff vesting"),
+        );
+
+        env.ledger().set_timestamp(1);
+        let claimable = contracts.vault.get_vesting(&vesting_id).claimable_amount;
+        assert!(claimable > 0);
+    }
+
+    #[test]
+    fn edge_case_vesting_duration_equals_cliff() {
+        let contracts = setup();
+        let env = &contracts.env;
+
+        let admin = Address::generate(env);
+        let beneficiary = Address::generate(env);
+        let token_admin = Address::generate(env);
+        let asset = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        StellarAssetClient::new(env, &asset).mint(&admin, &10_000_000);
+
+        let signer1 = Address::generate(env);
+        let signer2 = Address::generate(env);
+        let signers = Vec::from_array(env, [signer1, signer2]);
+
+        contracts.vault.initialize(&admin, &signers, &2, &asset);
+
+        let duration = 365 * 86400;
+        let vesting_id = contracts.vault.create_vesting(
+            &admin,
+            &beneficiary,
+            &10_000_000,
+            &duration,
+            &duration,
+            &text(env, "duration equals cliff"),
+        );
+
+        env.ledger().set_timestamp(duration + 1);
+        let claimable = contracts.vault.get_vesting(&vesting_id).claimable_amount;
+        assert_eq!(claimable, 10_000_000);
+    }
+
+    #[test]
+    fn edge_case_treasury_balance_exact_withdrawal_amount() {
+        let contracts = setup();
+        let env = &contracts.env;
+
+        let admin = Address::generate(env);
+        let signer = Address::generate(env);
+        let token_admin = Address::generate(env);
+        let asset = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        StellarAssetClient::new(env, &asset).mint(&signer, &5_000_000);
+        let recipient = Address::generate(env);
+        let signers = Vec::from_array(env, [signer.clone()]);
+
+        contracts.treasury.initialize(&admin, &1, &signers, &asset);
+        contracts.treasury.deposit(&signer, &5_000_000);
+
+        let tx_id = contracts.treasury.propose_withdrawal(
+            &signer,
+            &recipient,
+            &5_000_000,
+            &text(env, "withdraw entire balance"),
+        );
+
+        contracts.treasury.execute(&signer, &tx_id);
+        assert_eq!(contracts.treasury.get_balance(), 0);
+    }
+
+    #[test]
+    fn edge_case_governance_proposal_at_exact_voting_deadline() {
+        let contracts = setup();
+        let env = &contracts.env;
+
+        let owner = Address::generate(env);
+        let member1 = Address::generate(env);
+        let member2 = Address::generate(env);
+        let members = Vec::from_array(env, [member1.clone(), member2.clone()]);
+
+        contracts.governance.initialize(&owner, &members, &50, &100);
+
+        let proposal_id = contracts.governance.create_proposal(
+            &member1,
+            &text(env, "Deadline Test"),
+            &text(env, "Vote at exact deadline"),
+            &ProposalAction::General,
+            &0,
+            &Address::generate(env),
+        );
+
+        contracts.governance.vote(&member1, &proposal_id, &true);
+
+        env.ledger().set_timestamp(100);
+        contracts.governance.vote(&member2, &proposal_id, &true);
+
+        contracts.governance.finalize(&member1, &proposal_id);
+        let proposal = contracts.governance.get_proposal(&proposal_id);
+        assert_eq!(proposal.status, ProposalStatus::Passed);
+    }
 }


### PR DESCRIPTION
## Summary
Implements cancel mechanism for treasury proposals, adds Redis caching layer, edge case tests, and ensures loading states for data fetching.

## Issues Resolved
Closes #272
Closes #273
Closes #274
Closes #276

## Changes

### #272 - Treasury Withdrawal Proposal Cancellation
- Add cancel_transaction function to treasury contract
- Only proposer or admin can cancel pending proposals
- Unreserves funds when canceled to prevent deadlock
- Prevents approval/execution of canceled transactions
- Comprehensive test coverage including edge cases

### #273 - Redis Cache Layer
- Install ioredis package
- Create CacheService with standard cache operations
- Integrate cache into Treasury service (30s/60s/300s TTLs)
- Integrate cache into Governance service (60s/300s TTLs)
- Integrate cache into Vault service (60s TTL)
- Add REDIS_URL configuration

### #274 - Loading States
- Loading states already implemented via RouteSkeleton components
- Proper loading.tsx files for route-level Next.js loading
- Skeleton components configured for stats, lists, and tables

### #276 - Edge Case Test Coverage
- Single-signer treasury (threshold=1, signer_count=1)
- Governance with 100% quorum requirement
- Vault with zero cliff period
- Vesting with duration == cliff
- Treasury balance at exactly withdrawal amount
- Governance proposal voting at exact deadline