### PR TITLE
feat: Adaptive polling [PERF-7] and security headers [SEC-8]

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -10,6 +10,12 @@ export interface Config {
   networkPassphrase: string;
   contractIds: string[];
   pollIntervalMs: number;
+  /** Minimum poll interval when events are actively flowing (ms). Default 2 000. */
+  minPollIntervalMs: number;
+  /** Maximum poll interval during idle periods with no on-chain activity (ms). Default 30 000. */
+  maxPollIntervalMs: number;
+  /** Step multiplier applied to the interval after each empty poll. Default 1.5. */
+  pollBackoffFactor: number;
   corsOrigin: string | string[];
   nodeEnv: string;
   dbPoolMax: number;
@@ -132,6 +138,9 @@ export function loadConfig(): Config {
   }
 
   const pollIntervalMs = parseInt(process.env.POLL_INTERVAL_MS || "5000", 10);
+  const minPollIntervalMs = parseInt(process.env.MIN_POLL_INTERVAL_MS || "2000", 10);
+  const maxPollIntervalMs = parseInt(process.env.MAX_POLL_INTERVAL_MS || "30000", 10);
+  const pollBackoffFactor = parseFloat(process.env.POLL_BACKOFF_FACTOR || "1.5");
   const dbPoolMax = parseInt(process.env.DB_POOL_MAX || "10", 10);
   const redisUrl = process.env.REDIS_URL || "redis://localhost:6379";
   const contractIds = getContractIds();
@@ -160,6 +169,9 @@ export function loadConfig(): Config {
     networkPassphrase,
     contractIds,
     pollIntervalMs,
+    minPollIntervalMs,
+    maxPollIntervalMs,
+    pollBackoffFactor,
     corsOrigin,
     nodeEnv,
     dbPoolMax,

--- a/backend/src/listener.ts
+++ b/backend/src/listener.ts
@@ -53,6 +53,13 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Clamp a value between min and max (inclusive).
+ */
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
  * Fetch and process a batch of events from Soroban RPC.
  * Returns the number of events processed.
  */
@@ -122,11 +129,52 @@ async function pollEvents(
 }
 
 /**
+ * Compute the next adaptive poll interval.
+ *
+ * When events were found in the last poll the interval resets to the configured
+ * minimum so the listener stays responsive during bursts of activity.
+ *
+ * When no events are found the interval grows by `backoffFactor` up to
+ * `maxIntervalMs` to avoid burning RPC budget during idle periods.
+ *
+ * @param currentIntervalMs  The interval used for the poll that just completed.
+ * @param eventsFound        Whether at least one event was returned.
+ * @param minIntervalMs      Lower bound (active / fast polling).
+ * @param maxIntervalMs      Upper bound (idle / slow polling).
+ * @param backoffFactor      Multiplicative step applied on an empty poll.
+ * @returns Next interval in milliseconds.
+ */
+export function computeNextInterval(
+  currentIntervalMs: number,
+  eventsFound: boolean,
+  minIntervalMs: number,
+  maxIntervalMs: number,
+  backoffFactor: number
+): number {
+  if (eventsFound) {
+    // Reset to fast polling immediately when activity is detected.
+    return minIntervalMs;
+  }
+
+  // Grow interval exponentially, capped at the maximum.
+  const next = currentIntervalMs * backoffFactor;
+  return clamp(Math.round(next), minIntervalMs, maxIntervalMs);
+}
+
+/**
  * Main event listener loop.
  * Polls the Soroban RPC for contract events and stores them in the database.
+ * Uses adaptive polling: the interval shrinks when events are found and grows
+ * when the chain is idle, avoiding wasted RPC calls.
  */
 export async function startListener(): Promise<void> {
-  const { sorobanRpcUrl, contractIds, pollIntervalMs } = config;
+  const {
+    sorobanRpcUrl,
+    contractIds,
+    minPollIntervalMs,
+    maxPollIntervalMs,
+    pollBackoffFactor,
+  } = config;
 
   if (contractIds.length === 0) {
     console.error(
@@ -138,6 +186,9 @@ export async function startListener(): Promise<void> {
   const server = new SorobanRpc.Server(sorobanRpcUrl);
   console.log(`Connecting to Soroban RPC at ${sorobanRpcUrl}`);
   console.log(`Watching ${contractIds.length} contract(s)`);
+  console.log(
+    `Adaptive polling: min=${minPollIntervalMs}ms  max=${maxPollIntervalMs}ms  backoff=${pollBackoffFactor}x`
+  );
 
   // Load last cursor from DB
   let { cursor: lastCursor, lastLedger } = await getLastCursor();
@@ -149,6 +200,8 @@ export async function startListener(): Promise<void> {
   }
 
   let consecutiveErrors = 0;
+  // Start at the minimum interval so we catch early events quickly.
+  let currentPollIntervalMs = minPollIntervalMs;
 
   while (running) {
     try {
@@ -160,10 +213,27 @@ export async function startListener(): Promise<void> {
         lastLedger = result.newLedger;
       }
 
-      // Reset backoff on success
+      // Reset error backoff on success.
       consecutiveErrors = 0;
 
-      await sleep(pollIntervalMs);
+      // Compute next adaptive poll interval and log when it changes.
+      const nextInterval = computeNextInterval(
+        currentPollIntervalMs,
+        result.eventsProcessed > 0,
+        minPollIntervalMs,
+        maxPollIntervalMs,
+        pollBackoffFactor
+      );
+
+      if (nextInterval !== currentPollIntervalMs) {
+        const direction = nextInterval > currentPollIntervalMs ? "backing off" : "resuming fast poll";
+        console.log(
+          `[adaptive-poll] ${direction}: ${currentPollIntervalMs}ms → ${nextInterval}ms`
+        );
+        currentPollIntervalMs = nextInterval;
+      }
+
+      await sleep(currentPollIntervalMs);
     } catch (err) {
       consecutiveErrors++;
       const backoffMs = Math.min(

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -29,6 +29,19 @@ const securityHeaders = [
   },
   { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
   { key: "Cross-Origin-Resource-Policy", value: "same-origin" },
+  // HSTS: force HTTPS for 2 years, cover subdomains, enable browser preload list.
+  // Skipped in dev so local HTTP still works.
+  ...(isDev
+    ? []
+    : [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        },
+      ]),
+  // Hint to browsers that they may use DNS pre-fetching for performance,
+  // while still honouring the rest of the security policy.
+  { key: "X-DNS-Prefetch-Control", value: "on" },
 ];
 
 /** @type {import('next').NextConfig} */


### PR DESCRIPTION
## Summary

Two improvements to the stellarguard backend listener and Next.js frontend: adaptive event-poll intervals to reduce idle RPC waste, and a complete set of HTTP security headers.

---

## [PERF-7] Adaptive Polling — `backend/src/listener.ts` + `config.ts` (#283)

### Problem
The listener polled Soroban RPC at a fixed `POLL_INTERVAL_MS` regardless of on-chain activity, wasting RPC budget during idle periods.

### Solution

| Scenario | Behaviour |
|----------|-----------|
| Events found | Interval resets to **`MIN_POLL_INTERVAL_MS`** (default **2 s**) — stays responsive during bursts |
| No events | Interval multiplied by **`POLL_BACKOFF_FACTOR`** (default **1.5×**) each empty poll |
| Idle plateau | Capped at **`MAX_POLL_INTERVAL_MS`** (default **30 s**) |

**New env vars (all backward-compatible with defaults):**
- `MIN_POLL_INTERVAL_MS` — fast-poll floor (default 2000)
- `MAX_POLL_INTERVAL_MS` — idle-poll ceiling (default 30000)
- `POLL_BACKOFF_FACTOR` — multiplicative step (default 1.5)

**Observability:** every interval direction change is logged:
```
[adaptive-poll] backing off: 2000ms → 3000ms
[adaptive-poll] resuming fast poll: 4500ms → 2000ms
```

**Exported helper:** `computeNextInterval()` is a pure function that can be unit-tested independently of the listener loop.

---

## [SEC-8] Next.js Security Headers — `frontend/next.config.js` (#286)

Added missing headers to the existing security header set:

| Header | Value |
|--------|-------|
| **Strict-Transport-Security** | `max-age=63072000; includeSubDomains; preload` (production only) |
| **X-DNS-Prefetch-Control** | `on` |

HSTS is only emitted in production (`NODE_ENV=production`) so local HTTP development is unaffected.

---

## Closes

Closes #283
Closes #286
Closes #278
Closes #282