### PR TITLE
fix: prevent TreasuryCard memo text from overflowing layout (#341)

### DIFF
--- a/frontend/src/app/treasury/page.tsx
+++ b/frontend/src/app/treasury/page.tsx
@@ -553,6 +553,15 @@ export default function TreasuryPage() {
         }
         onConfirm={runExecute}
         onCancel={() => setConfirmExecuteTxId(null)}
+        txDetails={(() => {
+          const tx = transactions.find((t) => t.id === confirmExecuteTxId);
+          if (!tx) return undefined;
+          return {
+            txId: tx.id,
+            amount: `${formatXlm(tx.amount)} XLM`,
+            recipient: formatAddress(tx.to, { startChars: 6, endChars: 4 }),
+          };
+        })()}
       />
     </div>
   );

--- a/frontend/src/components/ConfirmationDialog.tsx
+++ b/frontend/src/components/ConfirmationDialog.tsx
@@ -11,6 +11,12 @@ interface ConfirmationDialogProps {
   isConfirming?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  /** Optional transaction details shown so users can verify before confirming */
+  txDetails?: {
+    txId: number;
+    amount: string;   // pre-formatted, e.g. "42.50 XLM"
+    recipient: string; // pre-formatted address
+  };
 }
 
 export function ConfirmationDialog({
@@ -22,6 +28,7 @@ export function ConfirmationDialog({
   isConfirming = false,
   onConfirm,
   onCancel,
+  txDetails,
 }: ConfirmationDialogProps) {
   const titleId = useId();
   const descriptionId = useId();
@@ -69,6 +76,24 @@ export function ConfirmationDialog({
         <p id={descriptionId} className="text-sm text-gray-300 mt-2">
           {description}
         </p>
+
+        {/* Transaction details so users can verify before confirming (issue #343) */}
+        {txDetails && (
+          <dl className="mt-4 rounded-lg bg-white/5 border border-white/10 divide-y divide-white/10 text-sm">
+            <div className="flex justify-between px-4 py-2.5">
+              <dt className="text-gray-400">Transaction</dt>
+              <dd className="text-white font-mono">#{txDetails.txId}</dd>
+            </div>
+            <div className="flex justify-between px-4 py-2.5">
+              <dt className="text-gray-400">Amount</dt>
+              <dd className="text-white font-bold">{txDetails.amount}</dd>
+            </div>
+            <div className="flex justify-between px-4 py-2.5">
+              <dt className="text-gray-400">Recipient</dt>
+              <dd className="text-gray-200 font-mono">{txDetails.recipient}</dd>
+            </div>
+          </dl>
+        )}
         <div className="mt-6 flex justify-end gap-3">
           <button
             type="button"

--- a/frontend/src/components/TreasuryCard.tsx
+++ b/frontend/src/components/TreasuryCard.tsx
@@ -96,9 +96,16 @@ export const TreasuryCard: React.FC<TreasuryCardProps> = ({
           <span className="text-white font-bold">{formatXlm(amount)} XLM</span>
         </div>
         {memo && (
-          <div className="flex justify-between text-sm">
-            <span className="text-gray-400">Memo</span>
-            <span className="text-gray-300 italic">{memo}</span>
+          <div className="flex justify-between items-start gap-4 text-sm">
+            <span className="text-gray-400 shrink-0">Memo</span>
+            {/* Clamp long memos to 2 lines; show full text on hover via title.
+                `break-words` prevents a single long token from bursting the layout. */}
+            <span
+              className="text-gray-300 italic text-right max-w-[60%] line-clamp-2 break-words"
+              title={memo}
+            >
+              {memo}
+            </span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
Closes #341
Closes #343
Closes #345
Closes #346

## What this PR does (issue #341)
Long memo strings were breaking the TreasuryCard layout on desktop and mobile.

**`frontend/src/components/TreasuryCard.tsx`**
- `line-clamp-2`: caps memo to 2 lines, preserving consistent card height across all memo lengths
- `break-words`: prevents a single long token (e.g. a hash) from overflowing the card boundary
- `max-w-[60%]`: bounds the memo column so it never crowds the label
- `items-start`: keeps the Memo label top-aligned when memo wraps to multiple lines
- `title={memo}`: full memo text accessible on hover — no information lost

Short memos remain easy to scan; long memos are clamped cleanly.