### PR TITLE
Fix governance proposal form: wallet guard, XLM precision, target validation, char counters

### DIFF
--- a/frontend/src/app/governance/page.tsx
+++ b/frontend/src/app/governance/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { useGovernance } from "@/hooks/useGovernance";
+import { useFreighter } from "@/hooks/useFreighter";
 import type {
   GovernanceProposal,
   GovernanceProposalAction,
@@ -71,6 +72,7 @@ function sortProposals(proposals: GovernanceProposal[], sort: SortKey): Governan
 
 export default function GovernancePage() {
   const { config, getConfig, getProposal, isLoading, error, createProposal } = useGovernance();
+  const { isConnected } = useFreighter();
   const [proposals, setProposals] = useState<GovernanceProposal[]>([]);
   const [statusFilter, setStatusFilter] = useState<"All" | GovernanceProposalStatus>("All");
   const [actionFilter, setActionFilter] = useState<"All" | GovernanceProposalAction>("All");
@@ -157,8 +159,10 @@ export default function GovernancePage() {
           </p>
         </div>
         <button
-          className="btn-primary"
+          className="btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={() => setShowCreateModal(true)}
+          disabled={!isConnected}
+          title={!isConnected ? "Connect your wallet to create proposals" : undefined}
         >
           + New Proposal
         </button>
@@ -278,6 +282,7 @@ export default function GovernancePage() {
       <CreateProposalModal
         isOpen={showCreateModal}
         isCreating={isCreating}
+        isWalletConnected={isConnected}
         onClose={() => setShowCreateModal(false)}
         onCreate={handleCreateProposal}
       />

--- a/frontend/src/components/CreateProposalModal.tsx
+++ b/frontend/src/components/CreateProposalModal.tsx
@@ -4,10 +4,12 @@ import { useEffect, useId, useState } from "react";
 import type { GovernanceProposalAction } from "@/lib/contractData";
 import { ACTION_DESCRIPTIONS } from "@/lib/contractData";
 import { isValidStellarAddress } from "@/lib/stellarAddress";
+import { parseXlmToStroops, sanitizeXlmInput } from "@/lib/formatters";
 
 interface CreateProposalModalProps {
   isOpen: boolean;
   isCreating?: boolean;
+  isWalletConnected?: boolean;
   onClose: () => void;
   onCreate: (data: {
     title: string;
@@ -29,9 +31,12 @@ const ACTIONS: GovernanceProposalAction[] = [
 export function CreateProposalModal({
   isOpen,
   isCreating = false,
+  isWalletConnected,
   onClose,
   onCreate,
 }: CreateProposalModalProps) {
+  const TITLE_MAX = 100;
+  const DESCRIPTION_MAX = 500;
   const titleId = useId();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -60,6 +65,11 @@ export function CreateProposalModal({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+
+    if (isWalletConnected === false) {
+      setError("Please connect your wallet first");
+      return;
+    }
 
     if (!title.trim()) {
       setError("Proposal title is required");
@@ -91,14 +101,15 @@ export function CreateProposalModal({
     }
 
     try {
-      const amountBigInt =
-        action === "Funding" ? BigInt(Math.floor(Number(amount) * 10 ** 7)) : BigInt(0);
+      const amountBigInt = action === "Funding" ? parseXlmToStroops(amount) : BigInt(0);
 
       await onCreate({
         title: title.trim(),
         description: description.trim(),
         action,
-        target: normalizedTarget,
+        target: (action === "Funding" || action === "AddMember" || action === "RemoveMember")
+          ? normalizedTarget
+          : "",
         amount: amountBigInt,
       });
 
@@ -153,8 +164,10 @@ export function CreateProposalModal({
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               disabled={isCreating}
+              maxLength={TITLE_MAX}
               className="w-full bg-gray-900 border border-stellar-border rounded px-3 py-2 text-sm text-white outline-none focus:border-primary-500 disabled:opacity-50"
             />
+            <p className="text-xs text-gray-500 text-right mt-1">{title.length}/{TITLE_MAX}</p>
           </div>
 
           <div>
@@ -168,8 +181,10 @@ export function CreateProposalModal({
               onChange={(e) => setDescription(e.target.value)}
               disabled={isCreating}
               rows={3}
+              maxLength={DESCRIPTION_MAX}
               className="w-full bg-gray-900 border border-stellar-border rounded px-3 py-2 text-sm text-white outline-none focus:border-primary-500 disabled:opacity-50 resize-none"
             />
+            <p className="text-xs text-gray-500 text-right mt-1">{description.length}/{DESCRIPTION_MAX}</p>
           </div>
 
           <div>
@@ -228,7 +243,7 @@ export function CreateProposalModal({
                 step="0.0000001"
                 min="0"
                 value={amount}
-                onChange={(e) => setAmount(e.target.value)}
+                onChange={(e) => setAmount(sanitizeXlmInput(e.target.value))}
                 disabled={isCreating}
                 className="w-full bg-gray-900 border border-stellar-border rounded px-3 py-2 text-sm text-white outline-none focus:border-primary-500 disabled:opacity-50"
               />


### PR DESCRIPTION
## Summary

- Adds wallet connection guard so the create-proposal button and form are disabled when no wallet is connected (fixes #352)
- Replaces float-based XLM→stroops conversion with precise integer arithmetic via `parseXlmToStroops` (fixes #353)
- Ensures `target` is always an empty string for `General` and `PolicyChange` proposals to prevent invalid address encoding (fixes #354)
- Adds character counters and `maxLength` enforcement on the title (100) and description (500) fields (fixes #355)

## Test plan

- [ ] Connect wallet → "+ New Proposal" button enabled; disconnect → button disabled
- [ ] Enter a Funding amount like `1.2345678` → stroops value is precisely `12345678` (no rounding drift)
- [ ] Submit a General/PolicyChange proposal → no address encoding error from the contract
- [ ] Title and description fields show live `n/max` counter and stop accepting input at the limit

Closes #352
Closes #353
Closes #354
Closes #355