### PR TITLE
fix: address FE-240, FE-254, FE-255, FE-257 across governance and proposal pages

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -66,3 +66,30 @@ body {
     @apply sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-lg focus:bg-stellar-blue focus:text-white focus:font-semibold focus:shadow-lg;
   }
 }
+
+/* ── Reduced motion ─────────────────────────────────────────────────────── */
+
+/* Utility to explicitly disable animations on a per-element basis */
+.reduced-motion {
+  animation: none !important;
+  transition: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .btn-primary,
+  .btn-secondary,
+  .nav-link,
+  .card,
+  .group-hover\:scale-110 {
+    transition: none !important;
+  }
+}

--- a/frontend/src/app/governance/page.tsx
+++ b/frontend/src/app/governance/page.tsx
@@ -91,13 +91,19 @@ export default function GovernancePage() {
         }
 
         const ids = Array.from({ length: count }, (_, i) => i + 1);
+
+        // Fetch proposals in bounded parallel batches (concurrency limit = 5)
         const loaded: GovernanceProposal[] = [];
-        for (const id of ids) {
-          try {
-            const proposal = await getProposal(id);
-            loaded.push(proposal);
-          } catch {
-            // Ignore sparse/unavailable ids from contract history.
+        const BATCH_SIZE = 5;
+        for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+          const batch = ids.slice(i, i + BATCH_SIZE);
+          const results = await Promise.allSettled(
+            batch.map((id) => getProposal(id)),
+          );
+          for (const result of results) {
+            if (result.status === "fulfilled") {
+              loaded.push(result.value);
+            }
           }
         }
 

--- a/frontend/src/app/proposals/[id]/page.tsx
+++ b/frontend/src/app/proposals/[id]/page.tsx
@@ -32,10 +32,14 @@ export default function ProposalDetailPage({
   const [countdown, setCountdown] = useState("Unknown");
   const [isFinalizing, setIsFinalizing] = useState(false);
   const [isExecuting, setIsExecuting] = useState(false);
+  const [loadError, setLoadError] = useState<unknown>(null);
   const [nowMs, setNowMs] = useState(Date.now());
 
+  const isValidId = Number.isFinite(id) && id > 0 && !Number.isNaN(id);
+
   const loadProposal = useCallback(async () => {
-    if (!Number.isFinite(id)) return;
+    setLoadError(null);
+    if (!isValidId) return;
     await getConfig();
     const [p, voted] = await Promise.all([
       getProposal(id),
@@ -44,10 +48,11 @@ export default function ProposalDetailPage({
     setProposal(p);
     setViewerHasVoted(voted);
     clearPendingVote(id);
-  }, [clearPendingVote, currentAddress, getConfig, getProposal, hasVoted, id]);
+  }, [clearPendingVote, currentAddress, getConfig, getProposal, hasVoted, id, isValidId]);
 
   useEffect(() => {
-    loadProposal().catch(() => {
+    loadProposal().catch((err) => {
+      setLoadError(err);
       toast.error("Failed to load proposal details");
     });
   }, [loadProposal]);
@@ -138,6 +143,33 @@ export default function ProposalDetailPage({
           ? "Voting is closed for this proposal."
           : "Your vote will be submitted on-chain immediately.";
 
+  if (!isValidId) {
+    return (
+      <div className="space-y-8 pb-32 md:pb-0">
+        <Link
+          href="/governance"
+          className="text-primary-400 hover:text-primary-300 text-sm"
+        >
+          ← Back to Governance
+        </Link>
+        <div className="card mx-auto max-w-2xl text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-red-400">
+            Invalid Proposal
+          </p>
+          <h1 className="mt-3 text-3xl font-bold text-white">
+            Proposal Not Found
+          </h1>
+          <p className="mt-3 text-sm text-gray-400">
+            The proposal ID &ldquo;{params.id}&rdquo; is not valid. Proposal IDs must be positive numbers.
+          </p>
+          <Link href="/governance" className="btn-primary mt-6 inline-block">
+            Browse Proposals
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-8 pb-32 md:pb-0">
       {/* Back Link */}
@@ -147,6 +179,29 @@ export default function ProposalDetailPage({
       >
         ← Back to Governance
       </Link>
+
+      {!!loadError && (
+        <div className="card mx-auto max-w-2xl text-center border-red-500/40">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-red-400">
+            Route Error
+          </p>
+          <h1 className="mt-3 text-3xl font-bold text-white">
+            Proposal unavailable
+          </h1>
+          <p className="mt-3 text-sm text-gray-400">
+            This proposal route failed to load. Retry to request the proposal details again.
+          </p>
+          <button
+            className="btn-primary mt-6"
+            onClick={() => loadProposal().catch((err) => {
+              setLoadError(err);
+              toast.error("Failed to load proposal details");
+            })}
+          >
+            Retry
+          </button>
+        </div>
+      )}
 
       {/* Proposal Header */}
       <div className="card">

--- a/frontend/src/app/template.tsx
+++ b/frontend/src/app/template.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 
 const variants = {
   hidden: { opacity: 0, x: -20, y: 0 },
@@ -9,6 +9,12 @@ const variants = {
 };
 
 export default function Template({ children }: { children: React.ReactNode }) {
+  const prefersReducedMotion = useReducedMotion();
+
+  if (prefersReducedMotion) {
+    return <main>{children}</main>;
+  }
+
   return (
     <motion.main
       variants={variants}


### PR DESCRIPTION
## Summary

### FE-240: Load governance proposals in bounded parallel batches (#349)
- Changed the sequential `for` loop in `governance/page.tsx` to fetch proposals in parallel batches with a concurrency limit of 5
- Uses `Promise.allSettled` to preserve the sparse-id tolerance (silently ignores missing proposals)

### FE-254: Guard invalid proposal route ids with a not-found state (#363)
- Validates `params.id` in `proposals/[id]/page.tsx` — checks that it is a finite positive number
- Invalid IDs render a clear "Proposal Not Found" card with a link back to governance, without calling any contract read methods

### FE-255: Add retry action to proposal detail load failure (#364)
- Added `loadError` state to `proposals/[id]/page.tsx`
- Failed proposal loads show an inline error card with a Retry button that calls `loadProposal`
- Toast is no longer the only feedback mechanism

### FE-257: Add reduced-motion handling for animated UI states (#366)
- Added `@media (prefers-reduced-motion: reduce)` rule in `globals.css` that disables animations/transitions for users who prefer reduced motion
- Added `.reduced-motion` utility class for per-element opt-out
- Updated `template.tsx` to use framer-motion's `useReducedMotion` hook — skips page transitions entirely when reduced motion is preferred

closes #363 
closes #364 
closes #366 
closes #349 
