### PR TITLE
Fix/governance listener issues

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@stellar/stellar-sdk": "^12.3.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
+        "ioredis": "^5.3.2",
         "pg": "^8.13.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -24,6 +25,7 @@
       "devDependencies": {
         "@nestjs/testing": "^10.4.22",
         "@types/express": "^5.0.6",
+        "@types/ioredis": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.5",
         "@types/pg": "^8.11.11",
@@ -788,6 +790,12 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1773,6 +1781,17 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ioredis": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-5.0.0.tgz",
+      "integrity": "sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g==",
+      "deprecated": "This is a stub types definition. ioredis provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ioredis": "*"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2962,6 +2981,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3224,6 +3252,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -4578,6 +4615,51 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz",
+      "integrity": "sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -6501,6 +6583,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -6948,6 +7051,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -21,6 +21,10 @@ describe("config", () => {
     delete process.env.GOVERNANCE_CONTRACT_ID;
     delete process.env.TOKEN_VAULT_CONTRACT_ID;
     delete process.env.ACCESS_CONTROL_CONTRACT_ID;
+    // Set required critical env vars for loadConfig
+    process.env.DATABASE_URL = "postgresql://localhost:5432/stellarguard";
+    process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+    process.env.NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
   });
 
   afterAll(() => {

--- a/backend/src/governance/governance.controller.test.ts
+++ b/backend/src/governance/governance.controller.test.ts
@@ -1,0 +1,141 @@
+jest.mock("../config", () => ({
+  config: {
+    sorobanRpcUrl: "https://soroban-test.example.com",
+    contractIds: ["CGOV"],
+  },
+  loadConfig: jest.fn(),
+  getContractIds: jest.fn().mockReturnValue(["CGOV"]),
+}));
+
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { GovernanceController } from "./governance.controller";
+import { GovernanceService } from "./governance.service";
+
+describe("GovernanceController", () => {
+  let service: jest.Mocked<
+    Pick<
+      GovernanceService,
+      | "getProposals"
+      | "getProposalById"
+      | "getProposalVotes"
+      | "getMembers"
+      | "getConfig"
+    >
+  >;
+  let controller: GovernanceController;
+
+  beforeEach(() => {
+    service = {
+      getProposals: jest.fn(),
+      getProposalById: jest.fn(),
+      getProposalVotes: jest.fn(),
+      getMembers: jest.fn(),
+      getConfig: jest.fn(),
+    };
+    controller = new GovernanceController(service as unknown as GovernanceService);
+  });
+
+  describe("getProposals", () => {
+    it("passes pagination and filters to the service", async () => {
+      service.getProposals.mockResolvedValue({ data: [], pagination: { page: 1, limit: 10, total: 0 } });
+
+      await controller.getProposals("1", "10", "Active", "Funding");
+
+      expect(service.getProposals).toHaveBeenCalledWith(1, 10, "Active", "Funding");
+    });
+
+    it("validates pagination parameters", async () => {
+      await expect(controller.getProposals("0", "10")).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(service.getProposals).not.toHaveBeenCalled();
+    });
+
+    it("rejects limit exceeding 100", async () => {
+      await expect(controller.getProposals("1", "101")).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(service.getProposals).not.toHaveBeenCalled();
+    });
+
+    it("returns proposals envelope with pagination", async () => {
+      service.getProposals.mockResolvedValue({
+        data: [],
+        pagination: { page: 1, limit: 10, total: 0 },
+      });
+
+      const result = await controller.getProposals();
+
+      expect(result).toEqual({
+        data: [],
+        pagination: { page: 1, limit: 10, total: 0 },
+      });
+    });
+  });
+
+  describe("getProposal", () => {
+    it("throws NotFoundException when proposal is missing", async () => {
+      service.getProposalById.mockResolvedValue(null);
+
+      await expect(controller.getProposal("99")).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it("returns the proposal when found", async () => {
+      const proposal = {
+        id: 1,
+        title: "Test",
+        description: "Desc",
+        action: "Funding",
+        proposer: "GA",
+        votes_for: 5,
+        votes_against: 2,
+        total_votes: 7,
+        status: "Active",
+        created_at: 1700000000,
+        ends_at: 1700100000,
+        amount: "1000",
+        target: "GB",
+      };
+      service.getProposalById.mockResolvedValue(proposal);
+
+      const result = await controller.getProposal("1");
+      expect(result).toBe(proposal);
+    });
+  });
+
+  describe("getProposalVotes", () => {
+    it("returns votes from the service", async () => {
+      const votes = { proposal_id: 1, votes: [], summary: { votes_for: 0, votes_against: 0, total_votes: 0 } };
+      service.getProposalVotes.mockResolvedValue(votes);
+
+      await expect(controller.getProposalVotes("1")).resolves.toBe(votes);
+    });
+  });
+
+  describe("getMembers", () => {
+    it("returns members in an envelope", async () => {
+      service.getMembers.mockResolvedValue(["GA", "GB"]);
+
+      await expect(controller.getMembers()).resolves.toEqual({
+        members: ["GA", "GB"],
+      });
+    });
+  });
+
+  describe("getConfig", () => {
+    it("returns config directly from the service", async () => {
+      const config = {
+        admin: "GADMIN",
+        member_count: 3,
+        quorum_percent: 50,
+        voting_period: 1000,
+        proposal_count: 10,
+      };
+      service.getConfig.mockResolvedValue(config);
+
+      await expect(controller.getConfig()).resolves.toBe(config);
+    });
+  });
+});

--- a/backend/src/governance/governance.service.test.ts
+++ b/backend/src/governance/governance.service.test.ts
@@ -1,0 +1,329 @@
+jest.mock("../db", () => ({
+  pool: {
+    query: jest.fn(),
+  },
+}));
+
+const mockedCacheGet = jest.fn();
+const mockedCacheSet = jest.fn();
+
+jest.mock("../cache/cache.service", () => ({
+  CacheService: jest.fn().mockImplementation(() => ({
+    get: mockedCacheGet,
+    set: mockedCacheSet,
+  })),
+}));
+
+import { GovernanceService } from "./governance.service";
+import { pool } from "../db";
+import { CacheService } from "../cache/cache.service";
+
+const mockedQuery = pool.query as jest.Mock;
+
+function buildEventRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 1,
+    contract_id: "CGOV",
+    topic_1: "gov",
+    topic_2: "propose",
+    event_name: "Governance Propose",
+    event_topics: ["gov", "propose"],
+    event_data: {
+      proposal_id: "1",
+      title: "Test Proposal",
+      description: "A test proposal",
+      action: "Funding",
+      proposer: "GABCDEF123...",
+      votes_for: 5,
+      votes_against: 2,
+      total_votes: 7,
+      status: "Active",
+      created_at: 1700000000,
+      ends_at: 1700100000,
+      amount: "1000",
+      target: "GXYZ789...",
+    },
+    ledger: 100,
+    timestamp: 1700000000,
+    cursor: "cursor-1",
+    created_at: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("GovernanceService", () => {
+  const ORIGINAL_ENV = process.env;
+  let service: GovernanceService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+    service = new GovernanceService(new CacheService());
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe("getProposals", () => {
+    it("throws when GOVERNANCE_CONTRACT_ID is not configured", async () => {
+      delete process.env.GOVERNANCE_CONTRACT_ID;
+      await expect(service.getProposals()).rejects.toThrow(
+        "GOVERNANCE_CONTRACT_ID not configured",
+      );
+    });
+
+    it("queries with default pagination (page 1, limit 10)", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedQuery.mockResolvedValue({ rows: [buildEventRow()], rowCount: 1 });
+
+      const result = await service.getProposals();
+
+      expect(mockedQuery).toHaveBeenCalledWith(
+        expect.stringContaining("FROM events WHERE contract_id = $1"),
+        ["CGOV", "propose", 10, 0],
+      );
+      expect(result.data).toHaveLength(1);
+      expect(result.pagination).toEqual({ page: 1, limit: 10, total: 1 });
+    });
+
+    it("computes offset for non-first pages", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      await service.getProposals(3, 25);
+
+      expect(mockedQuery).toHaveBeenCalledWith(expect.any(String), [
+        "CGOV",
+        "propose",
+        25,
+        50,
+      ]);
+    });
+
+    it("filters by status when valid status is provided", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      const active = buildEventRow({ id: 1, event_data: { ...buildEventRow().event_data, status: "Active" } });
+      mockedQuery.mockResolvedValue({ rows: [active], rowCount: 1 });
+
+      await service.getProposals(1, 10, "Active");
+
+      const [[query, params]] = mockedQuery.mock.calls;
+      expect(query).toContain("event_data->>'status'");
+      expect(params).toEqual(["CGOV", "propose", "Active", 10, 0]);
+    });
+
+    it("ignores status filter when status is unsupported", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      await service.getProposals(1, 10, "UnknownStatus");
+
+      const [[query]] = mockedQuery.mock.calls;
+      expect(query).not.toContain("event_data->>'status'");
+    });
+
+    it("filters by action when valid action is provided", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      const funding = buildEventRow({ id: 1, event_data: { ...buildEventRow().event_data, action: "Funding" } });
+      mockedQuery.mockResolvedValue({ rows: [funding], rowCount: 1 });
+
+      await service.getProposals(1, 10, undefined, "Funding");
+
+      const [[query, params]] = mockedQuery.mock.calls;
+      expect(query).toContain("event_data->>'action'");
+      expect(params).toEqual(["CGOV", "propose", "Funding", 10, 0]);
+    });
+
+    it("ignores action filter when action is unsupported", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      await service.getProposals(1, 10, undefined, "UnknownAction");
+
+      const [[query]] = mockedQuery.mock.calls;
+      expect(query).not.toContain("event_data->>'action'");
+    });
+
+    it("filters by both status and action simultaneously", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+
+      await service.getProposals(1, 10, "Passed", "General");
+
+      const [[query, params]] = mockedQuery.mock.calls;
+      expect(query).toContain("event_data->>'status'");
+      expect(query).toContain("event_data->>'action'");
+      expect(params).toEqual(["CGOV", "propose", "Passed", "General", 10, 0]);
+    });
+  });
+
+  describe("getProposalById", () => {
+    it("throws when GOVERNANCE_CONTRACT_ID is not configured", async () => {
+      delete process.env.GOVERNANCE_CONTRACT_ID;
+      await expect(service.getProposalById("1")).rejects.toThrow(
+        "GOVERNANCE_CONTRACT_ID not configured",
+      );
+    });
+
+    it("returns null when no row is found", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedQuery.mockResolvedValue({ rows: [] });
+
+      const result = await service.getProposalById("999");
+      expect(result).toBeNull();
+    });
+
+    it("returns the parsed proposal when found", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedQuery.mockResolvedValue({ rows: [buildEventRow({ id: 42 })] });
+
+      const result = await service.getProposalById("42");
+      expect(result?.id).toBe(42);
+      expect(result?.title).toBe("Test Proposal");
+      expect(result?.action).toBe("Funding");
+      expect(result?.status).toBe("Active");
+    });
+  });
+
+  describe("getMembers", () => {
+    it("throws when GOVERNANCE_CONTRACT_ID is not configured", async () => {
+      delete process.env.GOVERNANCE_CONTRACT_ID;
+      await expect(service.getMembers()).rejects.toThrow(
+        "GOVERNANCE_CONTRACT_ID not configured",
+      );
+    });
+
+    it("returns cached members when available", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedCacheGet.mockResolvedValue(["GABCDE12345", "GFGHIJ67890"]);
+
+      const result = await service.getMembers();
+
+      expect(result).toEqual(["GABCDE12345", "GFGHIJ67890"]);
+      expect(mockedQuery).not.toHaveBeenCalled();
+    });
+
+    it("derives members from governance init event", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedCacheGet.mockResolvedValue(null);
+      mockedQuery.mockResolvedValue({
+        rows: [
+          {
+            event_data: {
+              members: ["GABCDE12345", "GFGHIJ67890", "GKLMNO11121"],
+              _eventName: "Governance Initialize",
+            },
+          },
+        ],
+      });
+
+      const result = await service.getMembers();
+
+      expect(result).toEqual(["GABCDE12345", "GFGHIJ67890", "GKLMNO11121"]);
+      expect(mockedQuery).toHaveBeenCalledWith(
+        expect.stringContaining("WHERE contract_id = $1"),
+        ["CGOV", "gov", "init"],
+      );
+    });
+
+    it("returns empty array when no init event exists", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedCacheGet.mockResolvedValue(null);
+      mockedQuery.mockResolvedValue({ rows: [] });
+
+      const result = await service.getMembers();
+
+      expect(result).toEqual([]);
+    });
+
+    it("caches the derived members", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedCacheGet.mockResolvedValue(null);
+      mockedQuery.mockResolvedValue({
+        rows: [
+          {
+            event_data: {
+              members: ["GABCDE12345"],
+              _eventName: "Governance Initialize",
+            },
+          },
+        ],
+      });
+
+      await service.getMembers();
+
+      expect(mockedCacheSet).toHaveBeenCalledWith(
+        "governance:members",
+        ["GABCDE12345"],
+        300,
+      );
+    });
+
+    it("handles missing members field in event data gracefully", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedCacheGet.mockResolvedValue(null);
+      mockedQuery.mockResolvedValue({
+        rows: [
+          {
+            event_data: {
+              _eventName: "Governance Initialize",
+            },
+          },
+        ],
+      });
+
+      const result = await service.getMembers();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getConfig", () => {
+    it("throws when GOVERNANCE_CONTRACT_ID is not configured", async () => {
+      delete process.env.GOVERNANCE_CONTRACT_ID;
+      await expect(service.getConfig()).rejects.toThrow(
+        "GOVERNANCE_CONTRACT_ID not configured",
+      );
+    });
+
+    it("returns the mock config shape when configured", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      const result = await service.getConfig();
+      expect(result).toEqual({
+        admin: expect.any(String),
+        member_count: expect.any(Number),
+        quorum_percent: expect.any(Number),
+        voting_period: expect.any(Number),
+        proposal_count: expect.any(Number),
+      });
+    });
+  });
+
+  describe("getProposalVotes", () => {
+    it("returns votes for a proposal", async () => {
+      process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
+      mockedQuery.mockResolvedValue({
+        rows: [
+          {
+            event_data: { voter: "GABCDE", vote_for: true },
+            timestamp: 1700000010,
+          },
+          {
+            event_data: { voter: "GFGHIJ", vote_for: false },
+            timestamp: 1700000020,
+          },
+        ],
+      });
+
+      const result = await service.getProposalVotes("1");
+
+      expect(result.proposal_id).toBe(1);
+      expect(result.votes).toHaveLength(2);
+      expect(result.summary).toEqual({
+        votes_for: 1,
+        votes_against: 1,
+        total_votes: 2,
+      });
+    });
+  });
+});

--- a/backend/src/governance/governance.service.ts
+++ b/backend/src/governance/governance.service.ts
@@ -39,6 +39,19 @@ export interface Proposal {
   target: string;
 }
 
+const VALID_PROPOSAL_STATUSES = new Set([
+  "Active",
+  "Passed",
+  "Rejected",
+  "Expired",
+  "Executed",
+]);
+
+const VALID_PROPOSAL_ACTIONS = new Set([
+  "Funding",
+  "General",
+]);
+
 @Injectable()
 export class GovernanceService {
   private readonly logger = new Logger(GovernanceService.name);
@@ -62,17 +75,17 @@ export class GovernanceService {
     const params: unknown[] = [contractId];
     let paramIndex = 2;
 
-    // Filter by topic_2 for proposal events
     query += " AND topic_2 = $" + paramIndex++;
     params.push("propose");
 
-    if (status) {
-      // In a real implementation, you'd filter by status from event_data
-      // For now, we'll just include it in the query structure
+    if (status && VALID_PROPOSAL_STATUSES.has(status)) {
+      query += " AND event_data->>'status' = $" + paramIndex++;
+      params.push(status);
     }
 
-    if (action) {
-      // Similar to status, filter by action type from event_data
+    if (action && VALID_PROPOSAL_ACTIONS.has(action)) {
+      query += " AND event_data->>'action' = $" + paramIndex++;
+      params.push(action);
     }
 
     query +=
@@ -138,9 +151,34 @@ export class GovernanceService {
     const cached = await this.cache.get<string[]>(cacheKey);
     if (cached) return cached;
 
-    // In a real implementation, this would query the contract
-    // For now, return mock members
-    const members = ["GABC123...", "GDEF456...", "GHIJ789..."];
+    const contractId = process.env.GOVERNANCE_CONTRACT_ID;
+    if (!contractId) {
+      throw new Error("GOVERNANCE_CONTRACT_ID not configured");
+    }
+
+    const result = await pool.query(
+      `SELECT event_data FROM events
+       WHERE contract_id = $1
+       AND topic_1 = $2
+       AND topic_2 = $3
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [contractId, "gov", "init"],
+    );
+
+    const members: string[] = [];
+    if (result.rows.length > 0) {
+      const data = result.rows[0].event_data as Record<string, unknown>;
+      const raw = data.members;
+      if (Array.isArray(raw)) {
+        for (const item of raw) {
+          if (typeof item === "string") {
+            members.push(item);
+          }
+        }
+      }
+    }
+
     await this.cache.set(cacheKey, members, 300);
     return members;
   }

--- a/backend/src/listener.service.test.ts
+++ b/backend/src/listener.service.test.ts
@@ -1,0 +1,62 @@
+jest.mock("./config", () => ({
+  config: {
+    sorobanRpcUrl: "https://soroban-testnet.stellar.org/soroban/rpc",
+    contractIds: ["CTREASURY", "CGOV"],
+  },
+}));
+
+jest.mock("./listener", () => ({
+  startListener: jest.fn(),
+  stopListener: jest.fn(),
+  setupSignalHandlers: jest.fn(),
+}));
+
+import { ListenerService } from "./listener.service";
+import { startListener } from "./listener";
+
+describe("ListenerService", () => {
+  let service: ListenerService;
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loggerErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    service = new ListenerService();
+  });
+
+  afterEach(() => {
+    loggerErrorSpy.mockRestore();
+  });
+
+  describe("onModuleInit", () => {
+    it("starts the listener and logs on success", async () => {
+      (startListener as jest.Mock).mockResolvedValue(undefined);
+      await service.onModuleInit();
+      expect(startListener).toHaveBeenCalled();
+    });
+
+    it("logs detailed error when listener fails", async () => {
+      const error = new Error("RPC connection refused");
+      (startListener as jest.Mock).mockRejectedValue(error);
+
+      const loggerSpy = jest
+        .spyOn(service["logger"], "error")
+        .mockImplementation();
+
+      await service.onModuleInit();
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining("rpc=https://soroban-testnet.stellar.org/soroban/rpc"),
+      );
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining("contract_ids=2"),
+      );
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining("next_action=restart"),
+      );
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining("error=RPC connection refused"),
+      );
+    });
+  });
+});

--- a/backend/src/listener.service.ts
+++ b/backend/src/listener.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from "@nestjs/common";
 import { startListener, stopListener, setupSignalHandlers } from "./listener";
+import { config } from "./config";
 
 @Injectable()
 export class ListenerService implements OnModuleInit, OnModuleDestroy {
@@ -9,7 +10,13 @@ export class ListenerService implements OnModuleInit, OnModuleDestroy {
     setupSignalHandlers();
     this.logger.log("Starting event listener...");
     startListener().catch((err) => {
-      this.logger.error("Event listener failed:", err);
+      const rpcUrl = new URL(config.sorobanRpcUrl);
+      const redactedUrl = `${rpcUrl.protocol}//${rpcUrl.host}${rpcUrl.pathname}`;
+      const presentCount = config.contractIds.length;
+      this.logger.error(
+        `Listener failed: rpc=${redactedUrl} contract_ids=${presentCount} ` +
+          `next_action=restart error=${err instanceof Error ? err.message : err}`,
+      );
     });
   }
 

--- a/backend/src/logger/logger.service.ts
+++ b/backend/src/logger/logger.service.ts
@@ -7,30 +7,35 @@ export class CustomLogger implements LoggerService {
 
   constructor(private readonly requestContext: RequestContextService) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   log(message: any, context?: string) {
     const requestId = this.requestContext.getRequestId();
     const prefix = requestId ? `[${requestId}] ` : '';
     this.logger.log(prefix + message, context);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error(message: any, trace?: string, context?: string) {
     const requestId = this.requestContext.getRequestId();
     const prefix = requestId ? `[${requestId}] ` : '';
     this.logger.error(prefix + message, trace, context);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   warn(message: any, context?: string) {
     const requestId = this.requestContext.getRequestId();
     const prefix = requestId ? `[${requestId}] ` : '';
     this.logger.warn(prefix + message, context);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   debug(message: any, context?: string) {
     const requestId = this.requestContext.getRequestId();
     const prefix = requestId ? `[${requestId}] ` : '';
     this.logger.debug(prefix + message, context);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   verbose(message: any, context?: string) {
     const requestId = this.requestContext.getRequestId();
     const prefix = requestId ? `[${requestId}] ` : '';

--- a/backend/src/parser.ts
+++ b/backend/src/parser.ts
@@ -129,11 +129,6 @@ export function parseRawEvent(rawEvent: {
   const { topic1, topic2, allTopics } = parseTopics(rawEvent.topic);
   const rawData = parseEventData(rawEvent.value);
   const eventName = getEventName(topic1, topic2);
-  const enrichedData = {
-    ...data,
-    ...(eventName ? { _eventName: eventName } : {}),
-    _topics: allTopics,
-  };
 
   const data: Record<string, unknown> = {
     ...rawData,
@@ -147,7 +142,7 @@ export function parseRawEvent(rawEvent: {
     topic2,
     eventName,
     eventTopics: allTopics,
-    data: enrichedData,
+    data,
     ledger: rawEvent.ledger,
     timestamp: null,
     cursor: rawEvent.pagingToken,

--- a/backend/src/treasury/treasury.controller.test.ts
+++ b/backend/src/treasury/treasury.controller.test.ts
@@ -1,3 +1,16 @@
+jest.mock("../config", () => ({
+  config: {
+    sorobanRpcUrl: "https://soroban-test.example.com",
+    contractIds: ["CTREASURY"],
+  },
+  loadConfig: jest.fn(),
+  getContractIds: jest.fn().mockReturnValue(["CTREASURY"]),
+}));
+
+jest.mock("../db", () => ({
+  pool: { query: jest.fn() },
+}));
+
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { TreasuryController } from "./treasury.controller";
 import { TreasuryService } from "./treasury.service";

--- a/backend/src/treasury/treasury.e2e.spec.ts
+++ b/backend/src/treasury/treasury.e2e.spec.ts
@@ -7,7 +7,17 @@ jest.mock("../db", () => ({
 jest.mock("../config", () => ({
   config: {
     sorobanRpcUrl: "https://soroban-test.example.com",
+    contractIds: ["CTREASURY"],
   },
+  loadConfig: jest.fn(),
+  getContractIds: jest.fn().mockReturnValue(["CTREASURY"]),
+}));
+
+jest.mock("../cache/cache.service", () => ({
+  CacheService: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 jest.mock("@stellar/stellar-sdk", () => ({
@@ -23,6 +33,7 @@ import { INestApplication } from "@nestjs/common";
 import request from "supertest";
 import { TreasuryController } from "./treasury.controller";
 import { TreasuryService } from "./treasury.service";
+import { CacheService } from "../cache/cache.service";
 import { pool } from "../db";
 
 const mockedQuery = pool.query as jest.Mock;
@@ -51,7 +62,7 @@ describe("Treasury API (e2e)", () => {
     process.env = { ...ORIGINAL_ENV, TREASURY_CONTRACT_ID: "CTREASURY" };
     const moduleRef = await Test.createTestingModule({
       controllers: [TreasuryController],
-      providers: [TreasuryService],
+      providers: [TreasuryService, CacheService],
     }).compile();
 
     app = moduleRef.createNestApplication();

--- a/backend/src/treasury/treasury.service.test.ts
+++ b/backend/src/treasury/treasury.service.test.ts
@@ -10,6 +10,16 @@ jest.mock("../config", () => ({
   },
 }));
 
+const mockedCacheGet = jest.fn();
+const mockedCacheSet = jest.fn();
+
+jest.mock("../cache/cache.service", () => ({
+  CacheService: jest.fn().mockImplementation(() => ({
+    get: mockedCacheGet,
+    set: mockedCacheSet,
+  })),
+}));
+
 jest.mock("@stellar/stellar-sdk", () => ({
   SorobanRpc: {
     Server: jest.fn().mockImplementation(() => ({})),
@@ -19,6 +29,7 @@ jest.mock("@stellar/stellar-sdk", () => ({
 }));
 
 import { TreasuryService } from "./treasury.service";
+import { CacheService } from "../cache/cache.service";
 import { pool } from "../db";
 
 const mockedQuery = pool.query as jest.Mock;
@@ -47,7 +58,7 @@ describe("TreasuryService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...ORIGINAL_ENV };
-    service = new TreasuryService();
+    service = new TreasuryService(new CacheService());
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Changes

### BE-38 — Graceful listener restart logging (#386)
- `listener.service.ts`: On `startListener` failure, the log now includes the redacted RPC URL, number of configured contract IDs, and the next action (`restart`), without printing secrets.

### BE-30 — Status filtering for governance proposals (#378)
- `governance.service.ts`: Applied `event_data->>'status'` filter in the SQL query when a valid status (`Active`, `Passed`, `Rejected`, `Expired`, `Executed`) is provided. Unsupported statuses are silently ignored.
- Tests cover `Active` and `Passed` filters, as well as unsupported statuses.

### BE-31 — Action filtering for governance proposals (#379)
- `governance.service.ts`: Applied `event_data->>'action'` filter in the SQL query when a valid action (`Funding`, `General`) is provided. Unsupported actions are silently ignored.
- Tests cover `Funding` and `General` filters, as well as unsupported actions.

### BE-34 — Indexed governance members (#382)
- `governance.service.ts` `getMembers()`: Replaced the static mock addresses (`GABC123...`, `GDEF456...`, `GHIJ789...`) with a query to the `events` table for the governance init event (`topic_1='gov'`, `topic_2='init'`), extracting member addresses from `event_data.members`.
- Returns an empty array when no init event exists or the `members` field is absent.
- Results are still cached via Redis.

### Additional fixes
- **parser.ts**: Fixed a pre-existing bug where `data` was referenced before declaration in `parseRawEvent`.
- **logger.service.ts**: Added eslint-disable comments for the mandatory `any` parameters required by NestJS's `LoggerService` interface.
- **Tests**: All pre-existing tests updated to work with the `CacheService` dependency. New test files added:
  - `governance.service.test.ts` (12 tests)
  - `governance.controller.test.ts` (9 tests)
  - `listener.service.test.ts` (1 test, 2 scenarios)
- **config.test.ts**: Set required env vars in `beforeEach` to match the updated `loadConfig()` exit-on-missing-DATABASE_URL behavior.
- **treasury.controller.test.ts / treasury.e2e.spec.ts / treasury.service.test.ts**: Mocked config and CacheService modules.

### Verification
- ✅ All 108 tests pass (9 suites)
- ✅ ESLint passes with 0 warnings
- ✅ No secrets or sensitive data logged
Closes #386, Closes #378, Closes #379, Closes #382