### PR TITLE
fix: resolve pagination, config, and input validation issues

### DIFF
--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -28,6 +28,9 @@ describe("config", () => {
   });
 
   it("loads defaults for local development", () => {
+    process.env.DATABASE_URL = "postgresql://localhost:5432/stellarguard";
+    process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+    process.env.NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
     const warn = jest.spyOn(console, "warn").mockImplementation();
     const { loadConfig } = reloadConfig();
 
@@ -44,6 +47,9 @@ describe("config", () => {
   });
 
   it("collects configured contract ids in stable order", () => {
+    process.env.DATABASE_URL = "postgresql://localhost:5432/stellarguard";
+    process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+    process.env.NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
     process.env.TREASURY_CONTRACT_ID = " CTREASURY ";
     process.env.GOVERNANCE_CONTRACT_ID = "CGOV";
     process.env.TOKEN_VAULT_CONTRACT_ID = "";
@@ -55,6 +61,9 @@ describe("config", () => {
   });
 
   it("parses comma-separated CORS origins", () => {
+    process.env.DATABASE_URL = "postgresql://localhost:5432/stellarguard";
+    process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+    process.env.NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
     process.env.CORS_ORIGIN =
       "https://app.example.com, https://admin.example.com";
 
@@ -67,6 +76,9 @@ describe("config", () => {
   });
 
   it("warns for wildcard CORS in production", () => {
+    process.env.DATABASE_URL = "postgresql://localhost:5432/stellarguard";
+    process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+    process.env.NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
     process.env.NODE_ENV = "production";
     process.env.CORS_ORIGIN = "*";
     process.env.TREASURY_CONTRACT_ID = "CTREASURY";

--- a/backend/src/governance/governance.service.ts
+++ b/backend/src/governance/governance.service.ts
@@ -58,38 +58,44 @@ export class GovernanceService {
       throw new Error("GOVERNANCE_CONTRACT_ID not configured");
     }
 
-    let query = "SELECT * FROM events WHERE contract_id = $1";
+    const whereClauses: string[] = [];
     const params: unknown[] = [contractId];
     let paramIndex = 2;
 
-    // Filter by topic_2 for proposal events
-    query += " AND topic_2 = $" + paramIndex++;
+    whereClauses.push("contract_id = $1");
+    whereClauses.push("topic_2 = $" + paramIndex++);
     params.push("propose");
 
     if (status) {
-      // In a real implementation, you'd filter by status from event_data
-      // For now, we'll just include it in the query structure
+      whereClauses.push("event_data->>'status' = $" + paramIndex++);
+      params.push(status);
     }
 
     if (action) {
-      // Similar to status, filter by action type from event_data
+      whereClauses.push("event_data->>'action' = $" + paramIndex++);
+      params.push(action);
     }
 
-    query +=
-      " ORDER BY created_at DESC LIMIT $" +
-      paramIndex++ +
-      " OFFSET $" +
-      paramIndex;
-    params.push(limit, offset);
+    const whereSQL = whereClauses.join(" AND ");
 
-    const result = await pool.query(query, params);
+    const countResult = await pool.query(
+      `SELECT COUNT(*) FROM events WHERE ${whereSQL}`,
+      params,
+    );
+    const total = parseInt(countResult.rows[0].count, 10);
+
+    const dataParams = [...params, limit, offset];
+    const dataResult = await pool.query(
+      `SELECT * FROM events WHERE ${whereSQL} ORDER BY created_at DESC LIMIT $${paramIndex++} OFFSET $${paramIndex}`,
+      dataParams,
+    );
 
     return {
-      data: result.rows.map((row) => ProposalSchema.parse(row)),
+      data: dataResult.rows.map((row) => ProposalSchema.parse(row)),
       pagination: {
         page,
         limit,
-        total: result.rowCount || 0,
+        total,
       },
     };
   }
@@ -156,14 +162,28 @@ export class GovernanceService {
     const cached = await this.cache.get<GovernanceConfig>(cacheKey);
     if (cached) return cached;
 
-    // In a real implementation, this would query the contract
-    const configData = {
-      admin: "GADMIN...",
-      member_count: 3,
-      quorum_percent: 50,
-      voting_period: 1000,
-      proposal_count: 10,
+    const result = await pool.query(
+      `SELECT event_data FROM events
+       WHERE contract_id = $1 AND topic_1 = $2 AND topic_2 = $3
+       ORDER BY ledger DESC, id DESC
+       LIMIT 1`,
+      [contractId, "gov", "init"],
+    );
+
+    if (result.rows.length === 0) {
+      throw new Error("Governance config not found - no init event indexed");
+    }
+
+    const data = result.rows[0].event_data as Record<string, unknown>;
+
+    const configData: GovernanceConfig = {
+      admin: (data.admin as string) || "",
+      member_count: (data.member_count as number) || 0,
+      quorum_percent: (data.quorum_percent as number) || 0,
+      voting_period: (data.voting_period as number) || 0,
+      proposal_count: (data.proposal_count as number) || 0,
     };
+
     await this.cache.set(cacheKey, configData, 60);
     return configData;
   }

--- a/backend/src/parser.ts
+++ b/backend/src/parser.ts
@@ -129,16 +129,17 @@ export function parseRawEvent(rawEvent: {
   const { topic1, topic2, allTopics } = parseTopics(rawEvent.topic);
   const rawData = parseEventData(rawEvent.value);
   const eventName = getEventName(topic1, topic2);
-  const enrichedData = {
-    ...data,
-    ...(eventName ? { _eventName: eventName } : {}),
-    _topics: allTopics,
-  };
 
   const data: Record<string, unknown> = {
     ...rawData,
     _topics: allTopics,
     ...(eventName ? { _eventName: eventName } : {}),
+  };
+
+  const enrichedData = {
+    ...data,
+    ...(eventName ? { _eventName: eventName } : {}),
+    _topics: allTopics,
   };
 
   return {

--- a/backend/src/treasury/treasury.controller.test.ts
+++ b/backend/src/treasury/treasury.controller.test.ts
@@ -1,3 +1,26 @@
+jest.mock("../config", () => ({
+  config: {
+    databaseUrl: "postgresql://localhost:5432/test",
+    sorobanRpcUrl: "https://soroban-test.example.com",
+    redisUrl: "redis://localhost:6379",
+  },
+}));
+
+jest.mock("../cache/cache.service", () => ({
+  CacheService: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("@stellar/stellar-sdk", () => ({
+  SorobanRpc: {
+    Server: jest.fn().mockImplementation(() => ({})),
+  },
+  Address: jest.fn(),
+  Contract: jest.fn(),
+}));
+
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { TreasuryController } from "./treasury.controller";
 import { TreasuryService } from "./treasury.service";
@@ -55,7 +78,7 @@ describe("TreasuryController", () => {
   });
 
   it("passes normalized pagination to the service", async () => {
-    service.getTransactions.mockResolvedValue([]);
+    service.getTransactions.mockResolvedValue({ data: [], pagination: { page: 2, limit: 25, total: 0 } });
 
     await controller.getTransactions("2", "25");
 

--- a/backend/src/treasury/treasury.e2e.spec.ts
+++ b/backend/src/treasury/treasury.e2e.spec.ts
@@ -6,8 +6,17 @@ jest.mock("../db", () => ({
 
 jest.mock("../config", () => ({
   config: {
+    databaseUrl: "postgresql://localhost:5432/test",
     sorobanRpcUrl: "https://soroban-test.example.com",
+    redisUrl: "redis://localhost:6379",
   },
+}));
+
+jest.mock("../cache/cache.service", () => ({
+  CacheService: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 jest.mock("@stellar/stellar-sdk", () => ({
@@ -23,6 +32,7 @@ import { INestApplication } from "@nestjs/common";
 import request from "supertest";
 import { TreasuryController } from "./treasury.controller";
 import { TreasuryService } from "./treasury.service";
+import { CacheService } from "../cache/cache.service";
 import { pool } from "../db";
 
 const mockedQuery = pool.query as jest.Mock;
@@ -51,7 +61,7 @@ describe("Treasury API (e2e)", () => {
     process.env = { ...ORIGINAL_ENV, TREASURY_CONTRACT_ID: "CTREASURY" };
     const moduleRef = await Test.createTestingModule({
       controllers: [TreasuryController],
-      providers: [TreasuryService],
+      providers: [TreasuryService, CacheService],
     }).compile();
 
     app = moduleRef.createNestApplication();
@@ -76,18 +86,28 @@ describe("Treasury API (e2e)", () => {
   });
 
   it("serves transactions from the mocked test database", async () => {
-    mockedQuery.mockResolvedValue({ rows: [eventRow()] });
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [{ count: "1" }] })
+      .mockResolvedValueOnce({ rows: [eventRow()] });
 
     const response = await request(app.getHttpServer())
       .get("/api/treasury/transactions?page=1&limit=5")
       .expect(200);
 
-    expect(response.body).toEqual([expect.objectContaining({ id: 7 })]);
-    expect(mockedQuery).toHaveBeenCalledWith(expect.any(String), [
-      "CTREASURY",
-      5,
-      0,
-    ]);
+    expect(response.body).toEqual({
+      data: [expect.objectContaining({ id: 7 })],
+      pagination: { page: 1, limit: 5, total: 1 },
+    });
+    expect(mockedQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("SELECT COUNT(*)"),
+      ["CTREASURY"],
+    );
+    expect(mockedQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      ["CTREASURY", 5, 0],
+    );
   });
 
   it("returns 404 for missing transaction rows", async () => {

--- a/backend/src/treasury/treasury.service.test.ts
+++ b/backend/src/treasury/treasury.service.test.ts
@@ -7,7 +7,15 @@ jest.mock("../db", () => ({
 jest.mock("../config", () => ({
   config: {
     sorobanRpcUrl: "https://soroban-test.example.com",
+    redisUrl: "redis://localhost:6379",
   },
+}));
+
+jest.mock("../cache/cache.service", () => ({
+  CacheService: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+  })),
 }));
 
 jest.mock("@stellar/stellar-sdk", () => ({
@@ -19,6 +27,7 @@ jest.mock("@stellar/stellar-sdk", () => ({
 }));
 
 import { TreasuryService } from "./treasury.service";
+import { CacheService } from "../cache/cache.service";
 import { pool } from "../db";
 
 const mockedQuery = pool.query as jest.Mock;
@@ -47,7 +56,7 @@ describe("TreasuryService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...ORIGINAL_ENV };
-    service = new TreasuryService();
+    service = new TreasuryService(new CacheService());
   });
 
   afterAll(() => {
@@ -93,40 +102,53 @@ describe("TreasuryService", () => {
   describe("getTransactions", () => {
     it("queries with default pagination (page 1, limit 10)", async () => {
       process.env.TREASURY_CONTRACT_ID = "CTREASURY";
-      mockedQuery.mockResolvedValue({ rows: [buildEventRow()] });
+      mockedQuery
+        .mockResolvedValueOnce({ rows: [{ count: "5" }] })
+        .mockResolvedValueOnce({ rows: [buildEventRow()] });
 
       const result = await service.getTransactions();
 
-      expect(mockedQuery).toHaveBeenCalledWith(
+      expect(mockedQuery).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("SELECT COUNT(*) FROM events WHERE contract_id = $1"),
+        ["CTREASURY"],
+      );
+      expect(mockedQuery).toHaveBeenNthCalledWith(
+        2,
         expect.stringContaining("FROM events WHERE contract_id = $1"),
         ["CTREASURY", 10, 0],
       );
-      expect(result).toHaveLength(1);
-      expect(result[0]?.contract_id).toBe("CTREASURY");
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]?.contract_id).toBe("CTREASURY");
+      expect(result.pagination).toEqual({ page: 1, limit: 10, total: 5 });
     });
 
     it("computes the offset for non-first pages", async () => {
       process.env.TREASURY_CONTRACT_ID = "CTREASURY";
-      mockedQuery.mockResolvedValue({ rows: [] });
+      mockedQuery
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] })
+        .mockResolvedValueOnce({ rows: [] });
 
       await service.getTransactions(3, 25);
 
       // Page 3, limit 25 → offset 50
-      expect(mockedQuery).toHaveBeenCalledWith(expect.any(String), [
-        "CTREASURY",
-        25,
-        50,
-      ]);
+      expect(mockedQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining("FROM events WHERE contract_id = $1"),
+        ["CTREASURY", 25, 50],
+      );
     });
 
     it("validates each row through the Zod schema", async () => {
       process.env.TREASURY_CONTRACT_ID = "CTREASURY";
       const valid = buildEventRow({ id: 5 });
-      mockedQuery.mockResolvedValue({ rows: [valid] });
+      mockedQuery
+        .mockResolvedValueOnce({ rows: [{ count: "1" }] })
+        .mockResolvedValueOnce({ rows: [valid] });
 
       const result = await service.getTransactions();
 
-      expect(result[0]).toMatchObject({
+      expect(result.data[0]).toMatchObject({
         id: 5,
         contract_id: "CTREASURY",
         topic_1: "treasury",
@@ -136,11 +158,28 @@ describe("TreasuryService", () => {
 
     it("rejects when a row fails Zod validation", async () => {
       process.env.TREASURY_CONTRACT_ID = "CTREASURY";
-      mockedQuery.mockResolvedValue({
-        rows: [{ ...buildEventRow(), id: "not-a-number" }],
-      });
+      mockedQuery
+        .mockResolvedValueOnce({ rows: [{ count: "1" }] })
+        .mockResolvedValueOnce({
+          rows: [{ ...buildEventRow(), id: "not-a-number" }],
+        });
 
       await expect(service.getTransactions()).rejects.toBeDefined();
+    });
+
+    it("clamps invalid page and limit inputs", async () => {
+      process.env.TREASURY_CONTRACT_ID = "CTREASURY";
+      mockedQuery
+        .mockResolvedValueOnce({ rows: [{ count: "0" }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await service.getTransactions(0, 200);
+
+      expect(mockedQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        ["CTREASURY", 100, 0],
+      );
     });
   });
 

--- a/backend/src/treasury/treasury.service.ts
+++ b/backend/src/treasury/treasury.service.ts
@@ -66,15 +66,38 @@ export class TreasuryService {
   }
 
   async getTransactions(page: number = 1, limit: number = 10) {
+    if (!Number.isInteger(page) || page < 1) {
+      page = 1;
+    }
+    if (!Number.isInteger(limit) || limit < 1) {
+      limit = 10;
+    }
+    if (limit > 100) {
+      limit = 100;
+    }
+
     const offset = (page - 1) * limit;
     const contractId = process.env.TREASURY_CONTRACT_ID;
+
+    const countResult = await pool.query(
+      "SELECT COUNT(*) FROM events WHERE contract_id = $1",
+      [contractId],
+    );
+    const total = parseInt(countResult.rows[0].count, 10);
 
     const result = await pool.query(
       "SELECT * FROM events WHERE contract_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
       [contractId, limit, offset],
     );
 
-    return result.rows.map((row) => TransactionSchema.parse(row));
+    return {
+      data: result.rows.map((row) => TransactionSchema.parse(row)),
+      pagination: {
+        page,
+        limit,
+        total,
+      },
+    };
   }
 
   async getTransactionById(id: string) {


### PR DESCRIPTION
Fixes 4 backend issues related to pagination, config, and input validation.

### Changes

**BE-32 — Governance proposal pagination total count**
- Replaced `result.rowCount` (limited rows) with a separate `SELECT COUNT(*)` query using the same filters
- `pagination.total` now reflects all matching rows, not just the current page
- Refactored WHERE clause building to share between COUNT and data queries

**BE-26 — Treasury transaction pagination metadata**
- Added `SELECT COUNT(*)` query for the configured treasury contract
- Return shape changed from flat array to `{ data, pagination: { page, limit, total } }`
- Existing row parsing (Zod schema) is preserved

**BE-35 — Governance config from indexed events**
- Replaced hardcoded `admin`, `member_count`, `quorum_percent`, `voting_period`, `proposal_count` with data from the latest `gov`/`init` event in the `events` table
- Returns a clear error if no init event has been indexed
- Caching behavior is preserved

**BE-27 — Treasury pagination input validation**
- Added input clamping in `TreasuryService.getTransactions`: page defaults to 1 if < 1, limit defaults to 10 if < 1, limit capped at 100
- Works as defense-in-depth alongside controller-level Zod validation
- Invalid inputs produce a clear 400-level error through the controller path

### Additional fixes
- Fixed pre-existing `parser.ts` variable hoisting bug (used `data` before `const data` declaration)
- Fixed pre-existing `config.test.ts` missing required env vars causing `process.exit(1)`
- Added missing `CacheService` and Redis mocks to test files for proper DI resolution

### Testing
- All 78 tests pass (6 suites)
- Lint passes on all changed files (0 errors, 0 warnings)
- e2e tests cover paginated transaction responses with total count

Closes #380
Closes #374
Closes #383
Closes #375