### PR TITLE
feat: replace TreasuryService placeholder balance with indexed balanc…

### DIFF
--- a/backend/src/treasury/treasury.e2e.spec.ts
+++ b/backend/src/treasury/treasury.e2e.spec.ts
@@ -80,10 +80,12 @@ describe("Treasury API (e2e)", () => {
   });
 
   it("serves balance from the configured treasury service", async () => {
+    mockedQuery.mockResolvedValue({ rows: [{ total: 100000000 }] });
+
     await request(app.getHttpServer())
       .get("/api/treasury/balance")
       .expect(200)
-      .expect({ balance: "1000.0000000" });
+      .expect({ balance: "10.0000000" });
   });
 
   it("serves transactions from the mocked test database", async () => {

--- a/backend/src/treasury/treasury.service.test.ts
+++ b/backend/src/treasury/treasury.service.test.ts
@@ -10,7 +10,10 @@ jest.mock("../config", () => ({
   },
 }));
 
-
+jest.mock("../cache/cache.service", () => ({
+  CacheService: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
   })),
 }));
 
@@ -67,10 +70,52 @@ describe("TreasuryService", () => {
       );
     });
 
-    it("returns the placeholder balance when configured", async () => {
+    it("returns 0 when no deposit events exist", async () => {
       process.env.TREASURY_CONTRACT_ID = "CTREASURY";
+      mockedQuery.mockResolvedValue({ rows: [{ total: 0 }] });
+
       const result = await service.getBalance();
-      expect(result).toBe("1000.0000000");
+      expect(result).toBe("0.0000000");
+      expect(mockedQuery).toHaveBeenCalledWith(
+        expect.stringContaining("SUM(CAST((event_data->>'amount')"),
+        ["CTREASURY"],
+      );
+    });
+
+    it("sums deposit amounts from indexed events", async () => {
+      process.env.TREASURY_CONTRACT_ID = "CTREASURY";
+      mockedQuery.mockResolvedValue({ rows: [{ total: 50000000 }] });
+
+      const result = await service.getBalance();
+      expect(result).toBe("5.0000000");
+    });
+
+    it("converts stroops to decimal format with 7 places", async () => {
+      process.env.TREASURY_CONTRACT_ID = "CTREASURY";
+      mockedQuery.mockResolvedValue({ rows: [{ total: 123456789 }] });
+
+      const result = await service.getBalance();
+      expect(result).toBe("12.3456789");
+    });
+
+    it("returns cached balance on subsequent calls", async () => {
+      process.env.TREASURY_CONTRACT_ID = "CTREASURY";
+
+      const mockCache = new CacheService();
+      const getSpy = jest.spyOn(mockCache, 'get').mockResolvedValue(null);
+      const setSpy = jest.spyOn(mockCache, 'set').mockResolvedValue(undefined);
+
+      service = new TreasuryService(mockCache);
+      mockedQuery.mockResolvedValue({ rows: [{ total: 10000000 }] });
+
+      const result1 = await service.getBalance();
+
+      getSpy.mockResolvedValueOnce("1.0000000");
+      const result2 = await service.getBalance();
+
+      expect(result1).toBe("1.0000000");
+      expect(result2).toBe("1.0000000");
+      expect(mockedQuery).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/backend/src/treasury/treasury.service.ts
+++ b/backend/src/treasury/treasury.service.ts
@@ -37,10 +37,15 @@ export class TreasuryService {
     const cached = await this.cache.get<string>(cacheKey);
     if (cached) return cached;
 
-    // For now, return a placeholder balance
-    // In a real implementation, this would query the contract via RPC
-    // or read from the indexed database
-    const balance = "1000.0000000";
+    const result = await pool.query(
+      `SELECT COALESCE(SUM(CAST((event_data->>'amount') AS BIGINT)), 0) as total
+       FROM events
+       WHERE contract_id = $1 AND topic_1 = 'treasury' AND topic_2 = 'deposit'`,
+      [contractId],
+    );
+
+    const totalAmount = result.rows[0]?.total || 0;
+    const balance = (totalAmount / 10000000).toFixed(7);
     await this.cache.set(cacheKey, balance, 30);
     return balance;
   }


### PR DESCRIPTION
…e lookup

- Query deposit events from indexed database instead of returning hardcoded value
- Convert stroops amount to decimal format with 7 decimal places
- Handle missing contract_id consistently with other service methods
- Add comprehensive unit tests for empty result and populated result
- Update e2e test to mock database query

Fixes #372 [BE-24]

## Summary
<!-- Briefly describe what this PR does and why -->

## Related Issue
Closes #

## Changes
- 

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Self-reviewed the changes
- [ ] Tests added/updated and passing
- [ ] No breaking changes (or breaking changes documented)
- [ ] Documentation updated if needed


Closes #372