### PR TITLE
feat: reduce card and button border radii for dashboard-tighter look

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -38,15 +38,15 @@ body {
 
 @layer components {
   .btn-primary {
-    @apply bg-stellar-gradient hover:opacity-90 text-white font-semibold py-2.5 px-6 rounded-xl transition-all duration-300 shadow-lg shadow-primary-600/25 active:scale-[0.98];
+    @apply bg-stellar-gradient hover:opacity-90 text-white font-semibold py-2.5 px-6 rounded-lg transition-all duration-300 shadow-lg shadow-primary-600/25 active:scale-[0.98];
   }
 
   .btn-secondary {
-    @apply bg-white/5 hover:bg-white/10 text-white font-semibold py-2.5 px-6 rounded-xl border border-white/10 transition-all duration-300 backdrop-blur-md active:scale-[0.98];
+    @apply bg-white/5 hover:bg-white/10 text-white font-semibold py-2.5 px-6 rounded-lg border border-white/10 transition-all duration-300 backdrop-blur-md active:scale-[0.98];
   }
 
   .card {
-    @apply bg-stellar-card/60 backdrop-blur-xl border border-stellar-border/50 rounded-2xl p-6 shadow-glass;
+    @apply bg-stellar-card/60 backdrop-blur-xl border border-stellar-border/50 rounded-xl p-6 shadow-glass;
   }
 
   .gradient-text {
@@ -54,7 +54,7 @@ body {
   }
 
   .glass-panel {
-    @apply bg-white/5 backdrop-blur-lg border border-white/10 rounded-2xl;
+    @apply bg-white/5 backdrop-blur-lg border border-white/10 rounded-xl;
   }
 
   .nav-link {

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -185,7 +185,7 @@ export function DataTable<T extends object>({
       )}
 
       {/* Table wrapper */}
-      <div className="card overflow-x-auto p-0 rounded-2xl">
+      <div className="card overflow-x-auto p-0">
         <table
           className="w-full text-sm"
           aria-labelledby={caption ? captionId : undefined}

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -47,7 +47,7 @@ export function ProposalCard({
   return (
     <Link
       href={"/proposals/" + id}
-      className="block rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue focus-visible:ring-offset-2 focus-visible:ring-offset-stellar-darker"
+      className="block rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue focus-visible:ring-offset-2 focus-visible:ring-offset-stellar-darker"
     >
       <div className="card hover:border-primary-600/50 transition-colors cursor-pointer">
         <div className="flex justify-between items-start">

--- a/frontend/src/components/RouteSkeleton.tsx
+++ b/frontend/src/components/RouteSkeleton.tsx
@@ -21,11 +21,11 @@ export function RouteSkeleton({ title, description }: RouteSkeletonProps) {
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className="card space-y-4">
           <div className="h-5 w-32 rounded-lg bg-white/10" />
-          <div className="h-20 rounded-2xl bg-white/5" />
+          <div className="h-20 rounded-xl bg-white/5" />
         </div>
         <div className="card space-y-4">
           <div className="h-5 w-32 rounded-lg bg-white/10" />
-          <div className="h-20 rounded-2xl bg-white/5" />
+          <div className="h-20 rounded-xl bg-white/5" />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Reduce card, glass-panel, and button border-radius values by one step each for a tighter, more operational-dashboard look consistent with tool UI conventions.

## Related Issue
Closes #367 

## Changes
- **`frontend/src/app/globals.css`** — `.card` and `.glass-panel`: `rounded-2xl` (16px) → `rounded-xl` (12px); `.btn-primary` and `.btn-secondary`: `rounded-xl` (12px) → `rounded-lg` (8px)
- **`frontend/src/components/DataTable.tsx`** — Removed redundant `rounded-2xl` from the card wrapper (already inherited from `.card`)
- **`frontend/src/components/ProposalCard.tsx`** — Outer `<Link>` wrapper: `rounded-2xl` → `rounded-xl` to match the new card radius
- **`frontend/src/components/RouteSkeleton.tsx`** — Inner skeleton blocks inside cards: `rounded-2xl` → `rounded-xl` to stay visually consistent with parent cards

## Checklist
- [x] Code follows the project style guidelines
- [x] Self-reviewed the changes
- [x] Tests added/updated and passing
- [x] No breaking changes (or breaking changes documented)
- [ ] Documentation updated if needed
