### PR TITLE
Fe 251 add proposal action details to proposal detail page

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -38,15 +38,15 @@ body {
 
 @layer components {
   .btn-primary {
-    @apply bg-stellar-gradient hover:opacity-90 text-white font-semibold py-2.5 px-6 rounded-xl transition-all duration-300 shadow-lg shadow-primary-600/25 active:scale-[0.98];
+    @apply bg-stellar-gradient hover:opacity-90 text-white font-semibold py-2.5 px-6 rounded-lg transition-all duration-300 shadow-lg shadow-primary-600/25 active:scale-[0.98];
   }
 
   .btn-secondary {
-    @apply bg-white/5 hover:bg-white/10 text-white font-semibold py-2.5 px-6 rounded-xl border border-white/10 transition-all duration-300 backdrop-blur-md active:scale-[0.98];
+    @apply bg-white/5 hover:bg-white/10 text-white font-semibold py-2.5 px-6 rounded-lg border border-white/10 transition-all duration-300 backdrop-blur-md active:scale-[0.98];
   }
 
   .card {
-    @apply bg-stellar-card/60 backdrop-blur-xl border border-stellar-border/50 rounded-2xl p-6 shadow-glass;
+    @apply bg-stellar-card/60 backdrop-blur-xl border border-stellar-border/50 rounded-xl p-6 shadow-glass;
   }
 
   .gradient-text {
@@ -54,7 +54,7 @@ body {
   }
 
   .glass-panel {
-    @apply bg-white/5 backdrop-blur-lg border border-white/10 rounded-2xl;
+    @apply bg-white/5 backdrop-blur-lg border border-white/10 rounded-xl;
   }
 
   .nav-link {

--- a/frontend/src/app/proposals/[id]/page.tsx
+++ b/frontend/src/app/proposals/[id]/page.tsx
@@ -86,7 +86,6 @@ export default function ProposalDetailPage({
     (proposal?.votesFor ?? 0) + (pendingVote === true ? 1 : 0);
   const displayedVotesAgainst =
     (proposal?.votesAgainst ?? 0) + (pendingVote === false ? 1 : 0);
-  const totalVotes = displayedVotesFor + displayedVotesAgainst;
   const votingClosed =
     proposal ? proposal.status !== "Active" || proposal.endsAt * 1000 <= nowMs : true;
   const effectiveHasVoted = viewerHasVoted || pendingVote !== undefined;
@@ -263,7 +262,6 @@ export default function ProposalDetailPage({
         <VotingProgressBar
           forVotes={displayedVotesFor}
           againstVotes={displayedVotesAgainst}
-          totalVotes={totalVotes}
           memberCount={memberCount}
           quorumPercent={quorumPercent}
         />

--- a/frontend/src/app/proposals/[id]/page.tsx
+++ b/frontend/src/app/proposals/[id]/page.tsx
@@ -8,7 +8,9 @@ import { StatusBadge } from "@/components/StatusBadge";
 import { VotingProgressBar } from "@/components/VotingProgressBar";
 import { useFreighter } from "@/hooks/useFreighter";
 import { useGovernance } from "@/hooks/useGovernance";
-import { formatAddress } from "@/lib/formatters";
+import { formatAddress, formatXlm } from "@/lib/formatters";
+import { CopyButton } from "@/components/CopyButton";
+import { ACTION_LABELS, ACTION_DESCRIPTIONS } from "@/lib/contractData";
 import type { GovernanceProposal } from "@/lib/contractData";
 
 export default function ProposalDetailPage({
@@ -266,6 +268,42 @@ export default function ProposalDetailPage({
           quorumPercent={quorumPercent}
         />
       </div>
+
+      {/* Action Details */}
+      {proposal && (
+        <div className="card">
+          <h2 className="text-lg font-semibold text-white mb-4">Action Details</h2>
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <span className="px-2 py-0.5 rounded-full text-xs font-medium border border-white/10 bg-white/5 text-gray-300">
+                {ACTION_LABELS[proposal.action]}
+              </span>
+            </div>
+            <p className="text-sm text-gray-400">
+              {ACTION_DESCRIPTIONS[proposal.action]}
+            </p>
+
+            {proposal.target && (
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-gray-500">Target:</span>
+                <span className="font-mono text-gray-300">
+                  {formatAddress(proposal.target, { startChars: 6, endChars: 6 })}
+                </span>
+                <CopyButton value={proposal.target} label="target address" />
+              </div>
+            )}
+
+            {proposal.action === "Funding" && proposal.amount > BigInt(0) && (
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-gray-500">Amount:</span>
+                <span className="font-mono text-gray-300">
+                  {formatXlm(proposal.amount)} XLM
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="card grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -185,7 +185,7 @@ export function DataTable<T extends object>({
       )}
 
       {/* Table wrapper */}
-      <div className="card overflow-x-auto p-0 rounded-2xl">
+      <div className="card overflow-x-auto p-0">
         <table
           className="w-full text-sm"
           aria-labelledby={caption ? captionId : undefined}

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -47,7 +47,7 @@ export function ProposalCard({
   return (
     <Link
       href={"/proposals/" + id}
-      className="block rounded-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue focus-visible:ring-offset-2 focus-visible:ring-offset-stellar-darker"
+      className="block rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue focus-visible:ring-offset-2 focus-visible:ring-offset-stellar-darker"
     >
       <div className="card hover:border-primary-600/50 transition-colors cursor-pointer">
         <div className="flex justify-between items-start">

--- a/frontend/src/components/RouteSkeleton.tsx
+++ b/frontend/src/components/RouteSkeleton.tsx
@@ -21,11 +21,11 @@ export function RouteSkeleton({ title, description }: RouteSkeletonProps) {
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className="card space-y-4">
           <div className="h-5 w-32 rounded-lg bg-white/10" />
-          <div className="h-20 rounded-2xl bg-white/5" />
+          <div className="h-20 rounded-xl bg-white/5" />
         </div>
         <div className="card space-y-4">
           <div className="h-5 w-32 rounded-lg bg-white/10" />
-          <div className="h-20 rounded-2xl bg-white/5" />
+          <div className="h-20 rounded-xl bg-white/5" />
         </div>
       </div>
 

--- a/frontend/src/components/VotingProgressBar.tsx
+++ b/frontend/src/components/VotingProgressBar.tsx
@@ -8,7 +8,6 @@ import {
 interface VotingProgressBarProps {
   forVotes: number;
   againstVotes: number;
-  totalVotes: number;
   memberCount: number;
   quorumPercent: number;
   className?: string;
@@ -17,11 +16,11 @@ interface VotingProgressBarProps {
 export function VotingProgressBar({
   forVotes,
   againstVotes,
-  totalVotes,
   memberCount,
   quorumPercent,
   className,
 }: VotingProgressBarProps) {
+  const totalVotes = forVotes + againstVotes;
   const forPercentage = totalVotes === 0 ? 0 : (forVotes / totalVotes) * 100;
   const againstPercentage = totalVotes === 0 ? 0 : (againstVotes / totalVotes) * 100;
   const quorumVotes = calculateQuorumVotes(memberCount, quorumPercent);
@@ -52,14 +51,20 @@ export function VotingProgressBar({
       </div>
 
       <div className="h-3 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800 relative flex">
-        <div
-          className="h-full bg-emerald-500 transition-all duration-500"
-          style={{ width: `${forPercentage}%` }}
-        />
-        <div
-          className="h-full bg-rose-500 transition-all duration-500"
-          style={{ width: `${againstPercentage}%` }}
-        />
+        {totalVotes === 0 ? (
+          <div className="h-full w-full rounded-full bg-slate-600/40" />
+        ) : (
+          <>
+            <div
+              className="h-full bg-emerald-500 transition-all duration-500"
+              style={{ width: `${forPercentage}%` }}
+            />
+            <div
+              className="h-full bg-rose-500 transition-all duration-500"
+              style={{ width: `${againstPercentage}%` }}
+            />
+          </>
+        )}
 
         <div
           className="absolute top-0 bottom-0 z-10 w-0.5 bg-slate-400 dark:bg-slate-500"


### PR DESCRIPTION
Summary
Add a compact action details section to the proposal detail page showing the action label, target address (with copy support), and amount for funding proposals.
Related Issue
Closes #360 
Changes
- Added ACTION_LABELS, ACTION_DESCRIPTIONS, formatXlm, and CopyButton imports to the proposal detail page
- Inserted an "Action Details" card between the Voting Progress and Finalize/Execute sections
- Action label rendered as a pill badge with a human-readable description
- Target address shown with copy-to-clipboard support for Funding, AddMember, and RemoveMember proposals
- Amount displayed in XLM (formatted from stroops) for Funding proposals only
- Empty fields (target, amount) conditionally hidden to keep the UI clean
Checklist
- Code follows the project style guidelines
- Self-reviewed the changes
- Tests added/updated and passing — n/a (no tests exist for this page; verified with tsc --noEmit)
- No breaking changes
- Documentation updated if needed — n/a