### PR TITLE
feat(a11y): add focus trap to CreateProposalModal

### DIFF
--- a/frontend/src/components/CreateProposalModal.tsx
+++ b/frontend/src/components/CreateProposalModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type { GovernanceProposalAction } from "@/lib/contractData";
 import { ACTION_DESCRIPTIONS } from "@/lib/contractData";
 import { isValidStellarAddress } from "@/lib/stellarAddress";
@@ -18,6 +18,14 @@ interface CreateProposalModalProps {
     target: string;
     amount: bigint;
   }) => Promise<void>;
+}
+
+const FOCUSABLE_SELECTORS =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusable(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS));
 }
 
 const ACTIONS: GovernanceProposalAction[] = [
@@ -45,6 +53,8 @@ export function CreateProposalModal({
   const TITLE_MAX = 100;
   const DESCRIPTION_MAX = 500;
   const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const openerRef = useRef<Element | null>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [action, setAction] = useState<GovernanceProposalAction>("General");
@@ -57,6 +67,16 @@ export function CreateProposalModal({
   const isTargetAddressValid = isValidStellarAddress(normalizedTarget);
 
   useEffect(() => {
+    if (isOpen) {
+      openerRef.current = document.activeElement;
+      const focusable = getFocusable(dialogRef.current);
+      focusable[0]?.focus();
+    } else {
+      (openerRef.current as HTMLElement | null)?.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
     if (!isOpen) {
       return;
     }
@@ -64,6 +84,26 @@ export function CreateProposalModal({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape" && !isCreating) {
         onClose();
+        return;
+      }
+
+      if (event.key === "Tab") {
+        const focusable = getFocusable(dialogRef.current);
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (!first || !last) return;
+
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
       }
     };
 
@@ -203,6 +243,7 @@ export function CreateProposalModal({
       }}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}


### PR DESCRIPTION
Closes #357 

feat(a11y): add focus trap to CreateProposalModal [FE-248]

- Capture document.activeElement when the modal opens and restore it
  (the "+ New Proposal" button) when it closes
- Auto-focus the first focusable element inside the dialog on open
- Trap Tab and Shift+Tab within the dialog boundary so keyboard focus
  cannot escape to the page behind the overlay
- Merged Tab-trap logic into the existing Escape keydown listener to
  avoid a second window event handler


<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Title:</strong> <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">[FE-248] Add focus trap to CreateProposalModal</code></p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Branch:</strong> <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">feat/fe-248-focus-trap-create-proposal-modal</code> → <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">main</code></p><hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">CreateProposalModal</code> already had <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">role="dialog"</code>, <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">aria-modal="true"</code>, and Escape-key handling, but keyboard focus was not contained inside the modal. A user pressing Tab could reach elements behind the overlay, and focus was not returned to the triggering button after close — both WCAG 2.1 failures (success criteria 2.1.2 No Keyboard Trap and general focus-management guidance for dialogs).</p><hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">stellarguard/frontend/src/components/CreateProposalModal.tsx</code></strong></p>
What | Why
-- | --
Added useRef to imports | Required for dialogRef and openerRef
Added FOCUSABLE_SELECTORS constant + getFocusable() helper (module-level) | Encapsulates the standard interactive-element query used in both the open effect and the Tab handler
Added dialogRef (useRef<HTMLDivElement>) | Scopes the focusable query to the dialog container only
Added openerRef (useRef<Element \| null>) | Stores document.activeElement at open-time so it can be restored on close
New focus-management useEffect (deps: [isOpen]) | On open: saves opener, moves focus to first focusable child. On close: returns focus to the saved opener
Extended existing keydown useEffect with Tab handling | On Tab: if focus is on the last focusable element, wraps to first. On Shift+Tab: if focus is on the first, wraps to last. Escape behaviour is unchanged
Added ref={dialogRef} to the role="dialog" div | Connects the ref to the DOM node so getFocusable has the right container

<hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testing</h3><ol style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Open the Governance page with a connected wallet.</li><li>Click<span> </span><strong>+ New Proposal</strong><span> </span>— confirm the "Proposal Title" input is immediately focused.</li><li>Press<span> </span><strong>Tab</strong><span> </span>repeatedly — confirm focus cycles through Title → Description → Action → Cancel → Create Proposal, then wraps back to Title.</li><li>Press<span> </span><strong>Shift+Tab</strong><span> </span>from Title — confirm it wraps to "Create Proposal" button.</li><li>Press<span> </span><strong>Escape</strong><span> </span>— confirm the modal closes and focus lands on<span> </span><strong>+ New Proposal</strong>.</li><li>Re-open, begin submitting (<code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">isCreating = true</code>) — confirm Escape no longer closes the modal.</li></ol>