### PR TITLE
fix: multiple fixes across stellarguard

### DIFF
--- a/frontend/src/app/governance/page.tsx
+++ b/frontend/src/app/governance/page.tsx
@@ -247,6 +247,21 @@ export default function GovernancePage() {
             ))}
           </select>
         </div>
+        <div className="flex flex-col justify-end gap-2">
+          {(statusFilter !== "All" || actionFilter !== "All" || sortKey !== "newest") && (
+            <button
+              onClick={() => {
+                setStatusFilter("All");
+                setActionFilter("All");
+                setSortKey("newest");
+              }}
+              className="rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-gray-300 transition hover:bg-white/10 hover:text-white"
+              aria-label="Reset governance filters to defaults"
+            >
+              Reset filters
+            </button>
+          )}
+        </div>
         {error ? (
           <p className="text-sm text-red-400 md:col-span-4">
             {typeof error === "string" ? error : error.message}


### PR DESCRIPTION
Resolves four frontend issues across governance, wallet, and navigation UX.
Changes
[FE-241] Governance Filter Reset (#350)

Added Reset Filters button that appears when status/action/sort differ from defaults
Resets to status=All, action=All, sort=Newest in a single action
Active and past proposal sections update immediately on reset

[FE-250] Quorum Progress on ProposalCard (#359)

Added voter participation indicator using totalVotes / totalMembers
Avoids color-only communication for accessibility
Handles totalMembers=0 safely (no divide-by-zero)

[FE-218] Escape Key Support for MobileNav (#327)

Listens for Escape keydown while menu is open and closes it
Does not interfere with other key bindings
Outside-click and route-change close behavior unchanged

[FE-222] Wallet Network Label in WalletConnect (#331)

Displays Freighter-reported network name in the connected wallet chip
Label fits within header layout
Network mismatch banner behavior unchanged

Issues Closed
Closes #350 Closes #359 Closes #327 Closes #331